### PR TITLE
feat: adds support for url packages

### DIFF
--- a/pkg/nix/package_parser.go
+++ b/pkg/nix/package_parser.go
@@ -1,0 +1,115 @@
+package nix
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// NormalizedPackage represents a package in normalized form
+type NormalizedPackage struct {
+	// For nixpkgs packages
+	IsNixPackage bool
+	Name         string
+	Commit       string // Only for nix packages
+
+	// For URL packages
+	IsURLPackage bool
+	URLConfig    *URLPackage
+}
+
+// parsePackageList normalizes the mixed package format into a consistent structure
+func (n *Nix) parseAndUpdatePackageList() ([]NormalizedPackage, error) {
+	result := make([]NormalizedPackage, 0, len(n.InputPackages))
+
+	hasUpdate := false
+
+	for i, pkg := range n.InputPackages {
+		switch v := pkg.(type) {
+		case string:
+			// Simple string package from nixpkgs
+			np := NormalizedPackage{IsNixPackage: true}
+
+			if !strings.HasPrefix(v, "nixpkgs/") {
+				// Use default nixpkgs commit
+				np.Name = v
+				np.Commit = n.NixPkgs
+			} else {
+				// Parse nixpkgs/COMMIT#package format
+				parts := strings.Split(v, "#")
+				if len(parts) != 2 {
+					return nil, fmt.Errorf("invalid package format: %s", v)
+				}
+				np.Commit = strings.TrimPrefix(parts[0], "nixpkgs/")
+				np.Name = parts[1]
+			}
+			result = append(result, np)
+
+		case map[string]any:
+			// URL package config
+			jsonBytes, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse package config: %w", err)
+			}
+
+			var config URLPackage
+			if err := json.Unmarshal(jsonBytes, &config); err != nil {
+				return nil, fmt.Errorf("invalid package config: %w", err)
+			}
+
+			// Fetch SHA256 if not provided
+			if config.Sha256 == "" {
+				hash, err := fetchURLHash(config.URL)
+				if err != nil {
+					// Log warning but don't fail - let nix show the error
+					fmt.Fprintf(os.Stderr, "Warning: Failed to fetch SHA256 for %s: %v\n", config.URL, err)
+				} else {
+					config.Sha256 = hash
+					n.InputPackages[i] = config
+					hasUpdate = true
+				}
+			}
+
+			result = append(result, NormalizedPackage{
+				IsURLPackage: true,
+				URLConfig:    &config,
+			})
+
+		default:
+			return nil, fmt.Errorf("invalid package type (%T): must be string or object", v)
+		}
+	}
+
+	if hasUpdate {
+		if err := n.SyncToDisk(); err != nil {
+			return nil, fmt.Errorf("failed to sync nixy.yml to disk: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// getURLPackages returns only the URL packages
+func (n *Nix) getURLPackages() ([]*URLPackage, error) {
+	var urlPackages []*URLPackage
+	for _, np := range n.Packages {
+		if np.IsURLPackage {
+			urlPackages = append(urlPackages, np.URLConfig)
+		}
+	}
+
+	return urlPackages, nil
+}
+
+// getNixPackages returns only the nixpkgs packages grouped by commit
+func (n *Nix) getNixPackages() (map[string][]string, error) {
+	result := make(map[string][]string)
+	for _, np := range n.Packages {
+		if np.IsNixPackage {
+			result[np.Commit] = append(result[np.Commit], np.Name)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/nix/packages.go
+++ b/pkg/nix/packages.go
@@ -10,47 +10,60 @@ type ParsedPackages struct {
 	CommitsList  []string
 	PackagesMap  map[string][]string
 	LibrariesMap map[string][]string
+	URLPackages  []*URLPackage
 }
 
-// getPinnedPackages parses packages and groups them by nixpkgs commit
+// parsePackages parses packages and groups them by nixpkgs commit
 func (n *Nix) parsePackages() (*ParsedPackages, error) {
-	cache := make(map[string]struct{}, len(n.Packages)+len(n.Libraries))
+	cache := make(map[string]struct{})
 
 	pp := &ParsedPackages{
-		CommitsList:  make([]string, 0, len(n.Packages)+len(n.Libraries)),
-		PackagesMap:  make(map[string][]string, len(n.Packages)),
-		LibrariesMap: make(map[string][]string, len(n.Libraries)),
+		CommitsList:  make([]string, 0),
+		PackagesMap:  make(map[string][]string),
+		LibrariesMap: make(map[string][]string),
+		URLPackages:  make([]*URLPackage, 0),
 	}
 
-	parse := func(items []string, out map[string][]string) error {
-		for _, pkg := range items {
-			if !strings.HasPrefix(pkg, "nixpkgs/") {
-				pkg = fmt.Sprintf("nixpkgs/%s#%s", n.NixPkgs, pkg)
-			}
+	// Parse mixed package format
+	nixPackages, err := n.getNixPackages()
+	if err != nil {
+		return nil, err
+	}
+	
+	pp.PackagesMap = nixPackages
+	for commit := range nixPackages {
+		if _, ok := cache[commit]; !ok {
+			cache[commit] = struct{}{}
+			pp.CommitsList = append(pp.CommitsList, commit)
+		}
+	}
+	
+	// Get URL packages
+	urlPackages, err := n.getURLPackages()
+	if err != nil {
+		return nil, err
+	}
+	pp.URLPackages = urlPackages
 
-			parts := strings.Split(pkg, "#")
-			if len(parts) != 2 {
-				return fmt.Errorf("invalid package %s", pkg)
-			}
-
-			commit := strings.TrimPrefix(parts[0], "nixpkgs/")
-
-			if _, ok := cache[commit]; !ok {
-				cache[commit] = struct{}{}
-				pp.CommitsList = append(pp.CommitsList, commit)
-			}
-			out[commit] = append(out[commit], parts[1])
+	// Parse libraries (still string only)
+	for _, lib := range n.Libraries {
+		pkg := lib
+		if !strings.HasPrefix(pkg, "nixpkgs/") {
+			pkg = fmt.Sprintf("nixpkgs/%s#%s", n.NixPkgs, pkg)
 		}
 
-		return nil
-	}
+		parts := strings.Split(pkg, "#")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid library %s", pkg)
+		}
 
-	if err := parse(n.Packages, pp.PackagesMap); err != nil {
-		return nil, err
-	}
+		commit := strings.TrimPrefix(parts[0], "nixpkgs/")
 
-	if err := parse(n.Libraries, pp.LibrariesMap); err != nil {
-		return nil, err
+		if _, ok := cache[commit]; !ok {
+			cache[commit] = struct{}{}
+			pp.CommitsList = append(pp.CommitsList, commit)
+		}
+		pp.LibrariesMap[commit] = append(pp.LibrariesMap[commit], parts[1])
 	}
 
 	slices.Sort(pp.CommitsList)

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -56,6 +56,7 @@ func (n *Nix) Shell(ctx context.Context, shell string) error {
 		"nixpkgsCommitList": pp.CommitsList,
 		"packagesMap":       pp.PackagesMap,
 		"librariesMap":      pp.LibrariesMap,
+		"urlPackages":       pp.URLPackages,
 		"projectDir":        workspaceDir,
 		"profileDir": func() string {
 			if n.executor == BubbleWrapExecutor {

--- a/pkg/nix/utils.go
+++ b/pkg/nix/utils.go
@@ -1,0 +1,35 @@
+package nix
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// fetchURLHash fetches the SHA256 hash of a file at the given URL
+func fetchURLHash(url string) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch URL: status %d", resp.StatusCode)
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, resp.Body); err != nil {
+		return "", fmt.Errorf("failed to hash content: %w", err)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+


### PR DESCRIPTION
Adds support for URL packages, means you can have binaries from github releases directly in nixy.yml


```yaml
nixpkgs: 3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5
packages:
- go
- name: htmlc
  sha256: ea871429b9d3a78c0820e5b944cd598acbea72c5fe6ba86ee00b12c6a4536437
  url: https://github.com/nxtcoder17/htmlc/releases/download/v1.1.2/htmlc-linux-amd64
- name: k9s
  sha256: 3dc8238a554ad2051b91931f9da154188e222a9a1accc4410d7a87a654aab34e
  url: https://github.com/derailed/k9s/releases/download/v0.28.2/k9s_Linux_amd64.tar.gz
shellHook: |
  echo hi from SHELL HOOK
```