### PR TITLE
feat: pure environments in all executors

### DIFF
--- a/Runfile.yml
+++ b/Runfile.yml
@@ -3,7 +3,7 @@ tasks:
     watch:
       extensions:
         - .go
-        - .nix.tpl
+        - .tpl
     env:
       CGO_ENABLED: 0
     cmd:

--- a/pkg/nix/executor-bubblewrap.go
+++ b/pkg/nix/executor-bubblewrap.go
@@ -28,16 +28,20 @@ func UseBubbleWrap(profile *Profile) (*ExecutorArgs, error) {
 		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(profile.WorkspacesDir, dir),
 
 		EnvVars: ExecutorEnvVars{
-			User:                  os.Getenv("USER"),
-			Term:                  os.Getenv("TERM"),
-			TermInfo:              os.Getenv("TERMINFO"),
-			XDGSessionType:        os.Getenv("XDG_SESSION_TYPE"),
-			XDGCacheHome:          filepath.Join(fakeHomeMountedPath, ".cache"),
-			XDGDataHome:           filepath.Join(fakeHomeMountedPath, ".local", "share"),
-			NixConfig:             "experimental-features = nix-command flakes",
+			User:           "nixy",
+			Home:           fakeHomeMountedPath,
+			Term:           os.Getenv("TERM"),
+			TermInfo:       os.Getenv("TERMINFO"),
+			XDGSessionType: os.Getenv("XDG_SESSION_TYPE"),
+			XDGCacheHome:   filepath.Join(fakeHomeMountedPath, ".cache"),
+			XDGDataHome:    filepath.Join(fakeHomeMountedPath, ".local", "share"),
+			Path: []string{
+				filepath.Dir(profile.StaticNixBinPath),
+			},
 			NixyShell:             "true",
 			NixyWorkspaceDir:      dir,
 			NixyWorkspaceFlakeDir: "/workspace",
+			NixConfDir:            filepath.Join(profile.FakeHomeDir, ".config", "nix"),
 		},
 	}
 
@@ -88,6 +92,7 @@ func (nix *Nix) bubblewrapShell(ctx context.Context, command string, args ...str
 
 		// Custom User Home for nixy BubbleWrap shell
 		"--bind", nix.profile.FakeHomeDir, nix.executorArgs.FakeHomeMountedPath,
+		"--setenv", "HOME", nix.executorArgs.FakeHomeMountedPath,
 		"--bind", nix.executorArgs.WorkspaceFlakeDirHostPath, nix.executorArgs.WorkspaceFlakeDirMountedPath,
 
 		// Nix Store for nixy bubblewrap shell

--- a/pkg/nix/executor-docker.go
+++ b/pkg/nix/executor-docker.go
@@ -59,7 +59,6 @@ func (nix *Nix) dockerShell(ctx context.Context, command string, args ...string)
 	dockerCmd := []string{
 		"docker", "run",
 		"--hostname", "nixy",
-		// "--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 
 		// STEP: profile flake dir
@@ -87,8 +86,7 @@ func (nix *Nix) dockerShell(ctx context.Context, command string, args ...string)
 		dockerCmd = append(dockerCmd, "-e", k+"="+v)
 	}
 
-	// dockerCmd = append(dockerCmd, "--rm", "-it", "ghcr.io/nxtcoder17/nix:nonroot")
-	dockerCmd = append(dockerCmd, "--rm", "-it", "alpine:latest")
+	dockerCmd = append(dockerCmd, "--rm", "-it", "gcr.io/distroless/static-debian12")
 	dockerCmd = append(dockerCmd, command)
 	dockerCmd = append(dockerCmd, args...)
 

--- a/pkg/nix/executor-local.go
+++ b/pkg/nix/executor-local.go
@@ -41,15 +41,16 @@ func UseLocal(profile *Profile) (*ExecutorArgs, error) {
 
 		EnvVars: ExecutorEnvVars{
 			User:                  os.Getenv("USER"),
+			Home:                  profile.FakeHomeDir,
 			Term:                  os.Getenv("TERM"),
 			TermInfo:              os.Getenv("TERMINFO"),
 			XDGSessionType:        os.Getenv("XDG_SESSION_TYPE"),
 			XDGCacheHome:          filepath.Join(profile.FakeHomeDir, ".cache"),
 			XDGDataHome:           filepath.Join(profile.FakeHomeDir, ".local", "share"),
-			NixConfig:             "experimental-features = nix-command flakes",
-			NixyShell:             "true",
+			Path:                  []string{filepath.Dir(nixPath)},
 			NixyWorkspaceDir:      dir,
 			NixyWorkspaceFlakeDir: dir,
+			NixConfDir:            filepath.Join(profile.FakeHomeDir, ".config", "nix"),
 		},
 	}, nil
 }

--- a/pkg/nix/executor.go
+++ b/pkg/nix/executor.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 func XDGDataDir() string {
@@ -32,32 +33,37 @@ func (nix *Nix) PrepareShellCommand(ctx context.Context, command string, args ..
 }
 
 type ExecutorEnvVars struct {
-	User                  string `json:"USER"`
-	Term                  string `json:"TERM"`
-	TermInfo              string `json:"TERMINFO"`
-	XDGSessionType        string `json:"XDG_SESSION_TYPE"`
-	XDGCacheHome          string `json:"XDG_CACHE_HOME"`
-	XDGDataHome           string `json:"XDG_DATA_HOME"`
-	NixConfig             string `json:"NIX_CONFIG"`
-	NixyShell             string `json:"NIXY_SHELL"`
-	NixyWorkspaceDir      string `json:"NIXY_WORKSPACE_DIR"`
-	NixyWorkspaceFlakeDir string `json:"NIXY_WORKSPACE_FLAKE_DIR"`
-	NixyBuildHook         string `json:"NIXY_BUILD_HOOK"`
+	User                  string   `json:"USER"`
+	Home                  string   `json:"HOME"`
+	Term                  string   `json:"TERM"`
+	TermInfo              string   `json:"TERMINFO"`
+	Path                  []string `json:"PATH"`
+	XDGSessionType        string   `json:"XDG_SESSION_TYPE"`
+	XDGCacheHome          string   `json:"XDG_CACHE_HOME"`
+	XDGDataHome           string   `json:"XDG_DATA_HOME"`
+	NixyShell             string   `json:"NIXY_SHELL"`
+	NixyWorkspaceDir      string   `json:"NIXY_WORKSPACE_DIR"`
+	NixyWorkspaceFlakeDir string   `json:"NIXY_WORKSPACE_FLAKE_DIR"`
+	NixyBuildHook         string   `json:"NIXY_BUILD_HOOK"`
+	NixConfDir            string   `json:"NIX_CONF_DIR"`
 }
 
 func (e *ExecutorEnvVars) toMap() map[string]string {
 	return map[string]string{
-		"USER":                     e.User,
-		"TERM":                     e.Term,
-		"TERMINFO":                 e.TermInfo,
-		"XDG_SESSION_TYPE":         e.XDGSessionType,
-		"XDG_CACHE_HOME":           e.XDGCacheHome,
-		"XDG_DATA_HOME":            e.XDGDataHome,
-		"NIX_CONFIG":               e.NixConfig,
-		"NIXY_SHELL":               e.NixyShell,
+		"USER":             e.User,
+		"HOME":             e.Home,
+		"TERM":             e.Term,
+		"TERMINFO":         e.TermInfo,
+		"XDG_SESSION_TYPE": e.XDGSessionType,
+		"XDG_CACHE_HOME":   e.XDGCacheHome,
+		"XDG_DATA_HOME":    e.XDGDataHome,
+		// "NIX_CONFIG":               "experimental-features = nix-command flakes",
+		"NIXY_SHELL":               "true",
+		"PATH":                     strings.Join(e.Path, ":"),
 		"NIXY_WORKSPACE_DIR":       e.NixyWorkspaceDir,
 		"NIXY_WORKSPACE_FLAKE_DIR": e.NixyWorkspaceFlakeDir,
 		"NIXY_BUILD_HOOK":          e.NixyBuildHook,
+		"NIX_CONF_DIR":             e.NixConfDir,
 	}
 }
 

--- a/pkg/nix/packages.go
+++ b/pkg/nix/packages.go
@@ -113,7 +113,6 @@ func (n *Nix) GenerateWorkspaceFlakeParams() (*WorkspaceFlakeParams, error) {
 		PackagesMap:          map[string][]string{},
 		LibrariesMap:         map[string][]string{},
 		URLPackages:          []URLPackage{},
-		ProfileFlakeDir:      n.executorArgs.ProfileFlakeDirMountedPath,
 		WorkspaceDir:         workspaceDir,
 		Builds:               map[string]WorkspaceFlakePackgeBuild{},
 	}

--- a/pkg/nix/profile_base.go
+++ b/pkg/nix/profile_base.go
@@ -82,6 +82,15 @@ func NewProfile(ctx context.Context, name string) (*Profile, error) {
 		return nil, fmt.Errorf("failed to create profile flake.nix: %w", err)
 	}
 
+	b, err = templates.RenderNixConf()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(p.FakeHomeDir, ".config", "nix", "nix.conf"), b, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to create profile's nix.conf: %w", err)
+	}
+
 	return &p, nil
 }
 
@@ -105,6 +114,7 @@ func (p *Profile) CreateDirs() error {
 
 		// we need to have this nix dir to be used for nix store
 		filepath.Join(p.NixDir, "var", "nix"),
+		filepath.Join(p.FakeHomeDir, ".config", "nix"),
 	}
 
 	for _, dir := range dirs {

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -23,19 +23,32 @@ const (
 )
 
 func (nix *Nix) writeWorkspaceFlake() error {
+	if !nix.hasHashChanged {
+		return nil
+	}
+
 	flakeParams, err := nix.GenerateWorkspaceFlakeParams()
 	if err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(nix.executorArgs.WorkspaceFlakeDirHostPath, "shell-hook.sh"), []byte(nix.ShellHook), 0o744); err != nil {
-		return fmt.Errorf("write shell-hook.sh: %w", err)
+	shellHook, err := templates.RenderShellHook(templates.ShellHookParams{
+		EnvVars:   nix.executorArgs.EnvVars.toMap(),
+		ShellHook: nix.ShellHook,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(nix.executorArgs.WorkspaceFlakeDirHostPath, "shell-hook.sh"), []byte(shellHook), 0o744); err != nil {
+		return fmt.Errorf("failed to write shell-hook.sh: %w", err)
 	}
 
 	flake, err := templates.RenderWorkspaceFlake(flakeParams)
 	if err != nil {
-		return fmt.Errorf("render flake.nix: %w", err)
+		return fmt.Errorf("failed to render flake.nix: %w", err)
 	}
+
 	return os.WriteFile(filepath.Join(nix.executorArgs.WorkspaceFlakeDirHostPath, "flake.nix"), flake, 0o644)
 }
 
@@ -52,19 +65,43 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 		}
 	}
 
+	if n.executorArgs.EnvVars.NixConfDir == "" {
+		n.executorArgs.EnvVars.NixConfDir = n.executorArgs.ProfileFlakeDirMountedPath
+	}
+
 	scripts := []string{}
 
-	if n.executorArgs.NixBinaryMountedPath != "nix" {
-		scripts = append(scripts, fmt.Sprintf("PATH=%s:$PATH", filepath.Dir(n.executorArgs.NixBinaryMountedPath)))
+	for k, v := range n.executorArgs.EnvVars.toMap() {
+		scripts = append(scripts, fmt.Sprintf("export %s=%q", k, v))
 	}
 
 	scripts = append(scripts,
-		fmt.Sprintf("cd %s", n.executorArgs.PWD),
-		fmt.Sprintf("nix develop %s --quiet --quiet --override-input profile-flake %s --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, n.executorArgs.ProfileFlakeDirMountedPath, program),
+		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
+		fmt.Sprintf("export PATH=%s", strings.Join(n.executorArgs.EnvVars.Path, ":")),
+		// fmt.Sprintf("nix develop --quiet --quiet --override-input profile-flake %s --command %s", n.executorArgs.ProfileFlakeDirMountedPath, program),
+		// fmt.Sprintf("nix develop --profile /tmp/dev-profile --command %s", program),
+		// fmt.Sprintf("nix develop /tmp/dev-profile --command %s", program),
 	)
+
+	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, "dev-profile")) {
+		scripts = append(scripts,
+			fmt.Sprintf("nix develop --profile %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
+			// fmt.Sprintf("nix build .#devShells.default --out-link %s/dev-profile", n.executorArgs.WorkspaceFlakeDirMountedPath),
+		)
+	} else {
+		scripts = append(scripts,
+			fmt.Sprintf("nix develop %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
+		)
+	}
+
+	// scripts = append(scripts,
+	// 	fmt.Sprintf("nix develop %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
+	// )
 
 	nixShell := []string{
 		"shell",
+		"--ignore-environment",
+		// "--quiet", "--quiet",
 		fmt.Sprintf("nixpkgs/%s#bash", n.NixPkgs),
 		"--command",
 		"bash",
@@ -72,13 +109,11 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 		strings.Join(scripts, "\n"),
 	}
 
-	slog.Info("nix shell exec", "command", n.executorArgs.NixBinaryMountedPath)
 	cmd, err := n.PrepareShellCommand(ctx, n.executorArgs.NixBinaryMountedPath, nixShell...)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd.Env = n.executorArgs.EnvVars.ToEnviron()
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
@@ -87,7 +122,7 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 }
 
 func (n *Nix) Shell(ctx context.Context, program string) error {
-	cmd, err := n.nixShellExec(ctx, "")
+	cmd, err := n.nixShellExec(ctx, program)
 	if err != nil {
 		return err
 	}

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -78,15 +78,11 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 	scripts = append(scripts,
 		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
 		fmt.Sprintf("export PATH=%s", strings.Join(n.executorArgs.EnvVars.Path, ":")),
-		// fmt.Sprintf("nix develop --quiet --quiet --override-input profile-flake %s --command %s", n.executorArgs.ProfileFlakeDirMountedPath, program),
-		// fmt.Sprintf("nix develop --profile /tmp/dev-profile --command %s", program),
-		// fmt.Sprintf("nix develop /tmp/dev-profile --command %s", program),
 	)
 
 	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, "dev-profile")) {
 		scripts = append(scripts,
 			fmt.Sprintf("nix develop --profile %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
-			// fmt.Sprintf("nix build .#devShells.default --out-link %s/dev-profile", n.executorArgs.WorkspaceFlakeDirMountedPath),
 		)
 	} else {
 		scripts = append(scripts,
@@ -94,14 +90,10 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 		)
 	}
 
-	// scripts = append(scripts,
-	// 	fmt.Sprintf("nix develop %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
-	// )
-
 	nixShell := []string{
 		"shell",
 		"--ignore-environment",
-		// "--quiet", "--quiet",
+		"--quiet", "--quiet",
 		fmt.Sprintf("nixpkgs/%s#bash", n.NixPkgs),
 		"--command",
 		"bash",

--- a/pkg/nix/templates/build-hook.sh.tpl
+++ b/pkg/nix/templates/build-hook.sh.tpl
@@ -1,0 +1,19 @@
+{{- define "build-hook" }}
+
+{{- $projectDir := .ProjectDir }}
+{{- $buildTarget := .BuildTarget }}
+
+{{- range $p := .CopyPaths }}
+mkdir -p $(dirname {{$p}})
+cp -r {{$projectDir}}/{{$p}} ./$(dirname {{$p}})
+{{- end }}
+
+set -e
+mkdir -p {{$projectDir}}/.builds
+nix build --quiet --quiet .#{{$buildTarget}} -o {{$projectDir}}/.builds/{{$buildTarget}}
+
+{{- range $p := .CopyPaths }}
+rm -rf {{$p}}
+{{- end }}
+
+{{- end }}

--- a/pkg/nix/templates/nix.conf.tpl
+++ b/pkg/nix/templates/nix.conf.tpl
@@ -1,0 +1,7 @@
+{{- define "nix.conf" }}
+experimental-features = nix-command flakes
+http-connections = 40
+connect-timeout = 5
+{{- /* filter-syscalls = false */}}
+{{- /* sandbox = false */}}
+{{- end }}

--- a/pkg/nix/templates/profile-flake.nix.tpl
+++ b/pkg/nix/templates/profile-flake.nix.tpl
@@ -1,3 +1,5 @@
+{{- define "profile-flake" }}
+
 {{- $nixpkgsCommit := .NixPkgsCommit }}
 {
   description = "nixy profile flake";
@@ -41,3 +43,4 @@
       }
     );
 }
+{{- end }}

--- a/pkg/nix/templates/shell-env.sh.tpl
+++ b/pkg/nix/templates/shell-env.sh.tpl
@@ -1,0 +1,4 @@
+{{- range $k, $v := $envVars }}
+export {{$k}}='{{$v}}'
+{{- end }}
+

--- a/pkg/nix/templates/shell-hook.sh.tpl
+++ b/pkg/nix/templates/shell-hook.sh.tpl
@@ -1,0 +1,5 @@
+{{- define "shell-hook" }}
+
+{{- $shellHook := .ShellHook }}
+{{$shellHook}}
+{{- end }}

--- a/pkg/nix/templates/types.go
+++ b/pkg/nix/templates/types.go
@@ -14,11 +14,21 @@ var profileFlakeContent string
 //go:embed workspace-flake.nix.tpl
 var wsFlakeContent string
 
-var wsFlake *template.Template
+//go:embed shell-hook.sh.tpl
+var shellHookScript string
+
+//go:embed build-hook.sh.tpl
+var buildHookScript string
+
+//go:embed nix.conf.tpl
+var nixConf string
+
+var t *template.Template
 
 func init() {
-	wsFlake = template.New("workspace-flake")
-	wsFlake.Funcs(template.FuncMap{
+	t = template.New("templates")
+
+	t.Funcs(template.FuncMap{
 		"hasKey": func(item map[string]any, key string) bool {
 			if _, ok := item[key]; ok {
 				return true
@@ -27,14 +37,30 @@ func init() {
 		},
 		"hasPrefix": strings.HasPrefix,
 	})
-	if _, err := wsFlake.Parse(wsFlakeContent); err != nil {
-		panic(err)
+
+	if _, err := t.Parse(profileFlakeContent); err != nil {
+		panic(fmt.Errorf("failed to parse profile flake.nix: %w", err))
+	}
+	if _, err := t.Parse(wsFlakeContent); err != nil {
+		panic(fmt.Errorf("failed to parse workspace flake.nix: %w", err))
+	}
+
+	if _, err := t.Parse(shellHookScript); err != nil {
+		panic(fmt.Errorf("failed to parse shell hook script: %w", err))
+	}
+
+	if _, err := t.Parse(buildHookScript); err != nil {
+		panic(fmt.Errorf("failed to parse build hook script: %w", err))
+	}
+
+	if _, err := t.Parse(nixConf); err != nil {
+		panic(fmt.Errorf("failed to parse nix conf: %w", err))
 	}
 }
 
 func RenderWorkspaceFlake(values any) ([]byte, error) {
 	b := new(bytes.Buffer)
-	if err := wsFlake.ExecuteTemplate(b, "workspace-flake", values); err != nil {
+	if err := t.ExecuteTemplate(b, "workspace-flake", values); err != nil {
 		return nil, err
 	}
 
@@ -42,14 +68,47 @@ func RenderWorkspaceFlake(values any) ([]byte, error) {
 }
 
 func RenderProfileFlake(values any) ([]byte, error) {
-	t := template.New("profile-flake")
-	if _, err := t.Parse(profileFlakeContent); err != nil {
-		return nil, fmt.Errorf("failed to parse profile's flake.nix: %w", err)
-	}
-
 	b := new(bytes.Buffer)
 	if err := t.ExecuteTemplate(b, "profile-flake", values); err != nil {
 		return nil, fmt.Errorf("failed to render profile's flake.nix: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+type ShellHookParams struct {
+	EnvVars   map[string]string
+	ShellHook string
+}
+
+func RenderShellHook(params ShellHookParams) ([]byte, error) {
+	b := new(bytes.Buffer)
+	if err := t.ExecuteTemplate(b, "shell-hook", params); err != nil {
+		return nil, fmt.Errorf("failed to render shell-hook.sh: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+type BuildHookParams struct {
+	ProjectDir  string
+	BuildTarget string
+	CopyPaths   []string
+}
+
+func RenderBuildHook(params BuildHookParams) ([]byte, error) {
+	b := new(bytes.Buffer)
+	if err := t.ExecuteTemplate(b, "build-hook", params); err != nil {
+		return nil, fmt.Errorf("failed to render build-hook.sh: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+func RenderNixConf() ([]byte, error) {
+	b := new(bytes.Buffer)
+	if err := t.ExecuteTemplate(b, "nix.conf", nil); err != nil {
+		return nil, fmt.Errorf("failed to render nix.conf: %w", err)
 	}
 
 	return b.Bytes(), nil

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -1,3 +1,5 @@
+{{- define "workspace-flake" }}
+
 {{- $nixpkgsList := .NixPkgsCommits }}
 {{- $packagesMap := .PackagesMap }}
 {{- $librariesMap := .LibrariesMap }}
@@ -57,17 +59,17 @@
         os = builtins.elemAt (builtins.split "-" system) 2;
 
         packages = [
-          {{- range $k := $nixpkgsList -}}
-          {{- range $_, $v := (index $packagesMap $k) }}
-          pkgs_{{slice $k 0 7}}.{{$v}}
+          {{- range $k, $v := $packagesMap }}
+          {{- range $item := $v }}
+          pkgs_{{slice $k 0 7}}.{{$item}}
           {{- end }}
           {{- end }}
         ];
 
         libraries = pkgs.lib.makeLibraryPath [
-          {{- range $k := $nixpkgsList -}}
-          {{- range $_, $v := (index $librariesMap $k) }}
-          pkgs_{{slice $k 0 7}}.{{$v}}
+          {{- range $k, $v := $librariesMap }}
+          {{- range $item := $v }}
+          pkgs_{{slice $k 0 7}}.{{$item}}
           {{- end }}
           {{- end }}
         ];
@@ -160,9 +162,11 @@
             urlPackages;
 
           shellHook = ''
+            echo "Here, in shell hook"
             if [ -n "${libraries}" ]; then
               export LD_LIBRARY_PATH="${libraries}:$LD_LIBRARY_PATH"
             fi
+
             if [ -e shell-hook.sh ]; then
               source "shell-hook.sh"
             fi
@@ -171,7 +175,7 @@
               source "build-hook.sh"
             fi
 
-            {{- /* cd {{$projectDir}} */}}
+            cd {{$projectDir}}
           '';
         };
 
@@ -180,9 +184,9 @@
             closure = pkgs.buildEnv {
               name = "build-env";
               paths = [
-                {{- range $k := $nixpkgsList -}}
-                {{- range $_, $v := (index $build.PackagesMap $k) }}
-                pkgs_{{slice $k 0 7}}.{{$v}}
+                {{- range $k, $v := $build.PackagesMap }}
+                {{- range $item := $v }}
+                pkgs_{{slice $k 0 7}}.{{$item}}
                 {{- end }}
                 {{- end }}
               ];
@@ -192,7 +196,6 @@
             nativeBuildInputs = with pkgs; [
               {{- /* INFO: with uutils, date lib is missing nanosecond support */}}
               {{- /* uutils-coreutils-noprefix */}}
-
               coreutils-full
             ];
             SOURCE_DATE_EPOCH = "0";
@@ -229,3 +232,4 @@
     );
 }
 
+{{- end }}

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -5,7 +5,6 @@
 {{- $librariesMap := .LibrariesMap }}
 {{- $urlPackages := .URLPackages }}
 {{- $projectDir := .WorkspaceDir }}
-{{- $profileDir := .ProfileFlakeDir }}
 {{- $nixpkgsDefaultCommit := .NixPkgsDefaultCommit -}}
 {{- $builds := .Builds -}}
 
@@ -15,14 +14,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/{{$nixpkgsDefaultCommit}}";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-
-    {{- if $profileDir }}
-    profile-flake = {
-      url = "path:{{$profileDir}}";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
-    {{- end }}
 
     {{- range $_, $v := $nixpkgsList }}
     nixpkgs_{{slice $v 0 7}}.url = "github:nixos/nixpkgs/{{$v}}";
@@ -34,7 +25,6 @@
       {{- range $_, $v := $nixpkgsList -}}
       nixpkgs_{{slice $v 0 7}},
       {{- end }}
-      {{- if $profileDir }} profile-flake {{- end }}
     }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -154,15 +144,9 @@
         devShells.default = pkgs.mkShell {
           # hardeningDisable = [ "all" ];
 
-          buildInputs = 
-            {{- if $profileDir}} 
-            profile-flake.devShells.${system}.default.buildInputs ++ 
-            {{- end }}
-            packages ++
-            urlPackages;
+          buildInputs = packages ++ urlPackages;
 
           shellHook = ''
-            echo "Here, in shell hook"
             if [ -n "${libraries}" ]; then
               export LD_LIBRARY_PATH="${libraries}:$LD_LIBRARY_PATH"
             fi

--- a/pkg/nix/templates_types.go
+++ b/pkg/nix/templates_types.go
@@ -12,8 +12,7 @@ type WorkspaceFlakeParams struct {
 	LibrariesMap map[string][]string
 	URLPackages  []URLPackage
 
-	ProfileFlakeDir string
-	WorkspaceDir    string
+	WorkspaceDir string
 
 	Builds map[string]WorkspaceFlakePackgeBuild
 }


### PR DESCRIPTION
- a simplified build support, that does just enough to wrap your application in a minimal docker container

- improves shell launch speed by saving profiles, and using those profiles instead of re-evaluating flake.nix

- using go templates, instead of adhoc fmt.Sprintf's while creating shell exec command

## Summary by Sourcery

Use go templates to drive generation of all Nix artifacts and hooks, implement configuration change detection to speed up shell startup, and enforce pure environment isolation across all executors.

New Features:
- Introduce go template-based rendering for shell-hook.sh, build-hook.sh, nix.conf, workspace-flake.nix, and profile-flake.nix
- Add SHA256-based caching of workspace flake to skip regeneration when configuration is unchanged
- Enable pure Nix environments by explicitly setting HOME, PATH, NIX_CONF_DIR, and using --ignore-environment in shell executors

Enhancements:
- Refactor executors (docker, bubblewrap, local) to centralize environment variable handling and mount nix.conf directory
- Simplify workspace-flake.nix template by removing legacy profile-flake inputs and streamlining package iteration
- Switch Docker executor base image to distroless static-debian12