### PR TITLE
Feat/env support

### DIFF
--- a/pkg/nix/executor-docker.go
+++ b/pkg/nix/executor-docker.go
@@ -86,6 +86,12 @@ func (nix *Nix) dockerShell(ctx context.Context, command string, args ...string)
 		dockerCmd = append(dockerCmd, "-e", k+"="+v)
 	}
 
+	if !exists(nix.profile.StaticNixBinPath) {
+		if err := downloadStaticNixBinary(ctx, nix.profile.StaticNixBinPath); err != nil {
+			return nil, err
+		}
+	}
+
 	dockerCmd = append(dockerCmd, "--rm", "-it", "gcr.io/distroless/static-debian12")
 	dockerCmd = append(dockerCmd, command)
 	dockerCmd = append(dockerCmd, args...)

--- a/pkg/nix/nix.go
+++ b/pkg/nix/nix.go
@@ -44,6 +44,8 @@ type Nix struct {
 	Packages  []*NormalizedPackage `yaml:"packages"`
 	Libraries []string             `yaml:"libraries,omitempty"`
 
+	Env map[string]string `yaml:"env,omitempty"`
+
 	ShellHook string `yaml:"shellHook,omitempty"`
 
 	Builds map[string]Build `yaml:"builds,omitempty"`

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -75,6 +75,10 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 		scripts = append(scripts, fmt.Sprintf("export %s=%q", k, v))
 	}
 
+	for k, v := range n.Env {
+		scripts = append(scripts, fmt.Sprintf("export %s=%q", k, v))
+	}
+
 	scripts = append(scripts,
 		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
 		fmt.Sprintf("export PATH=%s", strings.Join(n.executorArgs.EnvVars.Path, ":")),

--- a/pkg/nix/templates/shell-env.sh.tpl
+++ b/pkg/nix/templates/shell-env.sh.tpl
@@ -1,4 +1,0 @@
-{{- range $k, $v := $envVars }}
-export {{$k}}='{{$v}}'
-{{- end }}
-


### PR DESCRIPTION
## Summary by Sourcery

Add environment variable support to Nix sessions and ensure the static Nix binary is available by downloading it on demand, while cleaning up an unused template file

New Features:
- Support custom environment variables in Nix shell sessions via the Env map
- Automatically download the static Nix binary if it's missing before starting a Docker shell

Enhancements:
- Remove the now-obsolete shell-env.sh.tpl template file