### PR TITLE
feat: adds back support for profile level flake.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,17 +120,7 @@ func main() {
 							},
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
-							profileName := c.StringArg("profile-name")
-							if profileName == "" {
-								v, ok := os.LookupEnv("NIXY_PROFILE")
-								if !ok {
-									fmt.Println("Must Specify one argument")
-									return nil
-								}
-								profileName = v
-							}
-
-							if err := nix.ProfileEdit(ctx, profileName); err != nil {
+							if err := nix.ProfileEdit(ctx, c.Args().First()); err != nil {
 								return err
 							}
 

--- a/pkg/nix/executor.go
+++ b/pkg/nix/executor.go
@@ -33,19 +33,25 @@ func (nix *Nix) PrepareShellCommand(ctx context.Context, command string, args ..
 }
 
 type ExecutorEnvVars struct {
-	User                  string   `json:"USER"`
-	Home                  string   `json:"HOME"`
-	Term                  string   `json:"TERM"`
-	TermInfo              string   `json:"TERMINFO"`
-	Path                  []string `json:"PATH"`
-	XDGSessionType        string   `json:"XDG_SESSION_TYPE"`
-	XDGCacheHome          string   `json:"XDG_CACHE_HOME"`
-	XDGDataHome           string   `json:"XDG_DATA_HOME"`
-	NixyShell             string   `json:"NIXY_SHELL"`
-	NixyWorkspaceDir      string   `json:"NIXY_WORKSPACE_DIR"`
-	NixyWorkspaceFlakeDir string   `json:"NIXY_WORKSPACE_FLAKE_DIR"`
-	NixyBuildHook         string   `json:"NIXY_BUILD_HOOK"`
-	NixConfDir            string   `json:"NIX_CONF_DIR"`
+	User           string   `json:"USER"`
+	Home           string   `json:"HOME"`
+	Term           string   `json:"TERM"`
+	TermInfo       string   `json:"TERMINFO"`
+	Path           []string `json:"PATH"`
+	XDGSessionType string   `json:"XDG_SESSION_TYPE"`
+	XDGCacheHome   string   `json:"XDG_CACHE_HOME"`
+	XDGDataHome    string   `json:"XDG_DATA_HOME"`
+
+	// Nixy Env Vars
+	NixyExecutor        string `json:"NIXY_EXECUTOR"`
+	NixyProfile         string `json:"NIXY_PROFILE"`
+	NixyUseProfileFlake string `json:"NIXY_USE_PROFILE_FLAKE"`
+
+	NixyShell             string `json:"NIXY_SHELL"`
+	NixyWorkspaceDir      string `json:"NIXY_WORKSPACE_DIR"`
+	NixyWorkspaceFlakeDir string `json:"NIXY_WORKSPACE_FLAKE_DIR"`
+	NixyBuildHook         string `json:"NIXY_BUILD_HOOK"`
+	NixConfDir            string `json:"NIX_CONF_DIR"`
 }
 
 func (e *ExecutorEnvVars) toMap() map[string]string {
@@ -58,6 +64,11 @@ func (e *ExecutorEnvVars) toMap() map[string]string {
 		"XDG_CACHE_HOME":   e.XDGCacheHome,
 		"XDG_DATA_HOME":    e.XDGDataHome,
 		// "NIX_CONFIG":               "experimental-features = nix-command flakes",
+
+		"NIXY_EXECUTOR":          string(nixyEnvVars.NixyExecutor),
+		"NIXY_PROFILE":           nixyEnvVars.NixyProfile,
+		"NIXY_USE_PROFILE_FLAKE": fmt.Sprintf("%v", nixyEnvVars.NixyUseProfileFlake),
+
 		"NIXY_SHELL":               "true",
 		"PATH":                     strings.Join(e.Path, ":"),
 		"NIXY_WORKSPACE_DIR":       e.NixyWorkspaceDir,

--- a/pkg/nix/profile_base.go
+++ b/pkg/nix/profile_base.go
@@ -73,7 +73,7 @@ func NewProfile(ctx context.Context, name string) (*Profile, error) {
 		return nil, fmt.Errorf("failed to save profile into a profile.json: %w", err)
 	}
 
-	b, err := templates.RenderProfileFlake(ProfileFlakeParams{NixPkgsCommit: nixpkgsHash})
+	b, err := templates.RenderProfileFlake(templates.ProfileFlakeParams{NixPkgsCommit: nixpkgsHash})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nix/templates/types.go
+++ b/pkg/nix/templates/types.go
@@ -58,7 +58,35 @@ func init() {
 	}
 }
 
-func RenderWorkspaceFlake(values any) ([]byte, error) {
+// copy of pkg/nix.URLPackage
+type URLPackage struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	Sha256 string `yaml:"sha256,omitempty"`
+}
+
+type WorkspaceFlakeParams struct {
+	NixPkgsDefaultCommit string
+	NixPkgsCommits       []string
+
+	PackagesMap  map[string][]string
+	LibrariesMap map[string][]string
+	URLPackages  []URLPackage
+
+	WorkspaceDir string
+
+	Builds map[string]WorkspaceFlakePackgeBuild
+
+	UseProfileFlake bool
+	ProfileFlakeDir string
+}
+
+type WorkspaceFlakePackgeBuild struct {
+	PackagesMap map[string][]string
+	Paths       []string
+}
+
+func RenderWorkspaceFlake(values *WorkspaceFlakeParams) ([]byte, error) {
 	b := new(bytes.Buffer)
 	if err := t.ExecuteTemplate(b, "workspace-flake", values); err != nil {
 		return nil, err
@@ -67,7 +95,11 @@ func RenderWorkspaceFlake(values any) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func RenderProfileFlake(values any) ([]byte, error) {
+type ProfileFlakeParams struct {
+	NixPkgsCommit string
+}
+
+func RenderProfileFlake(values ProfileFlakeParams) ([]byte, error) {
 	b := new(bytes.Buffer)
 	if err := t.ExecuteTemplate(b, "profile-flake", values); err != nil {
 		return nil, fmt.Errorf("failed to render profile's flake.nix: %w", err)

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -8,6 +8,9 @@
 {{- $nixpkgsDefaultCommit := .NixPkgsDefaultCommit -}}
 {{- $builds := .Builds -}}
 
+{{- $useProfileFlake := .UseProfileFlake }}
+{{- $profileFlakeDir := .ProfileFlakeDir }}
+
 {
   description = "nixy project development workspace";
 
@@ -15,6 +18,10 @@
     nixpkgs.url = "github:nixos/nixpkgs/{{$nixpkgsDefaultCommit}}";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
 
+    {{- if $useProfileFlake }}
+    profile-flake.url = "{{$profileFlakeDir}}";
+    {{- end }}
+    
     {{- range $_, $v := $nixpkgsList }}
     nixpkgs_{{slice $v 0 7}}.url = "github:nixos/nixpkgs/{{$v}}";
     {{- end }}
@@ -22,6 +29,11 @@
 
   outputs = {
       self, nixpkgs, flake-utils,
+
+      {{- if $useProfileFlake }}
+      profile-flake,
+      {{- end }}
+
       {{- range $_, $v := $nixpkgsList -}}
       nixpkgs_{{slice $v 0 7}},
       {{- end }}
@@ -144,7 +156,7 @@
         devShells.default = pkgs.mkShell {
           # hardeningDisable = [ "all" ];
 
-          buildInputs = packages ++ urlPackages;
+          buildInputs = {{- if $useProfileFlake }} profile-flake.devShells.${system}.default.buildInputs ++ {{- end }} packages ++ urlPackages;
 
           shellHook = ''
             if [ -n "${libraries}" ]; then

--- a/pkg/nix/templates_types.go
+++ b/pkg/nix/templates_types.go
@@ -4,24 +4,3 @@ import (
 	_ "embed"
 )
 
-type WorkspaceFlakeParams struct {
-	NixPkgsDefaultCommit string
-	NixPkgsCommits       []string
-
-	PackagesMap  map[string][]string
-	LibrariesMap map[string][]string
-	URLPackages  []URLPackage
-
-	WorkspaceDir string
-
-	Builds map[string]WorkspaceFlakePackgeBuild
-}
-
-type WorkspaceFlakePackgeBuild struct {
-	PackagesMap map[string][]string
-	Paths       []string
-}
-
-type ProfileFlakeParams struct {
-	NixPkgsCommit string
-}


### PR DESCRIPTION
It was kind of needed where one needs a set of tools only for his purposes, like development environment setup

## Summary by Sourcery

Enable conditional inclusion of a per-profile flake and refactor environment variable handling to drive profile and executor settings from the environment.

New Features:
- Introduce a NIXY_USE_PROFILE_FLAKE environment variable to toggle profile-level flake support
- Add global environment variable struct for NIXY_PROFILE, NIXY_EXECUTOR, and NIXY_USE_PROFILE_FLAKE

Enhancements:
- Refactor workspace-flake template to conditionally include the profile flake input and prepend its buildInputs
- Update CLI to require explicit profile argument and remove fallback logic
- Restructure template parameter types (WorkspaceFlakeParams, ProfileFlakeParams, URLPackage) and remove redundant functions