### PR TITLE
feat: os.Stat check always failed due to dangling symlink of dev-profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           buildx_cache: "ghcr.io/${{ github.repository }}:buildx-cache-${{needs.github-release.outputs.sanitized_ref}}"
         run: |+
           docker buildx build -f ./Dockerfile.build \
+            --build-arg VERSION="${{ needs.github-release.outputs.version }}"
             --cache-to type=registry,ref="$buildx_cache",mode=max,compression=zstd,compression-level=13,force-compression=true \
             --cache-from type=registry,ref="$buildx_cache" \
             --cache-from type=registry,ref="$buildx_cache_master" \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,6 +13,7 @@ ENV GOMODCACHE=$CACHE_DIR/gomodcache
 ENV GOCACHE=$CACHE_DIR/gocache
 
 ENV CGO_ENABLED=0
+ARG VERSION
 
 RUN --mount=type=bind,source=flake.nix,target=flake.nix \
   --mount=type=bind,source=flake.lock,target=flake.lock \
@@ -30,7 +31,7 @@ RUN --mount=type=bind,source=.,target=/app \
   --mount=type=cache,target=$GOMODCACHE \
   --mount=type=cache,target=$GOCACHE \
   <<EOF
-nix develop --command run build:all binpath=/out/nixy
+nix develop --command run build:all binpath=/out/nixy version=$VERSION
 EOF
 
 FROM scratch

--- a/Runfile.yml
+++ b/Runfile.yml
@@ -7,8 +7,9 @@ tasks:
     env:
       CGO_ENABLED: 0
     cmd:
-      - go build -o ./bin/nixy ./cmd/main.go
-      - echo "Build Successful ✅"
+      - run: build
+        env:
+          version: "dev"
 
   build:
     env:
@@ -21,14 +22,17 @@ tasks:
       GOARCH:
         default:
           sh: go env GOARCH
+      version:
+        required: true
     cmd:
-      - go build -v -o $binpath-$GOOS-$GOARCH -ldflags="-s -w" -tags urfave_cli_no_docs ./cmd/
+      - go build -v -o $binpath-$GOOS-$GOARCH -ldflags="-s -w -X 'main.Version=$version'" -tags urfave_cli_no_docs ./cmd/
+      - echo "Build Successful ✅"
 
   build:all:
     parallel: true
-    # env:
-    #   GOMODCACHE: "/tmp/y/modcache"
-    #   GOCACHE: "/tmp/y/gocache"
+    env:
+      version:
+        required: true
     cmd:
       - run: build
         env:

--- a/pkg/nix/executor-bubblewrap.go
+++ b/pkg/nix/executor-bubblewrap.go
@@ -49,7 +49,7 @@ func UseBubbleWrap(profile *Profile) (*ExecutorArgs, error) {
 }
 
 func exists(path string) bool {
-	_, err := os.Stat(path)
+	_, err := os.Lstat(path)
 	if err == nil {
 		return true
 	}

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nxtcoder17/nixy/pkg/nix/templates"
 )
@@ -117,7 +118,7 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 		)
 	} else {
 		scripts = append(scripts,
-			fmt.Sprintf("nix develop %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
+			fmt.Sprintf("nix develop --offline %s/dev-profile --command %s", n.executorArgs.WorkspaceFlakeDirMountedPath, program),
 		)
 	}
 
@@ -145,6 +146,7 @@ func (n *Nix) nixShellExec(ctx context.Context, program string) (*exec.Cmd, erro
 }
 
 func (n *Nix) Shell(ctx context.Context, program string) error {
+	start := time.Now()
 	cmd, err := n.nixShellExec(ctx, program)
 	if err != nil {
 		return err
@@ -152,7 +154,7 @@ func (n *Nix) Shell(ctx context.Context, program string) error {
 
 	slog.Debug("Executing", "command", cmd.String())
 	defer func() {
-		slog.Debug("Shell Exited")
+		slog.Debug("Shell Exited", "in", fmt.Sprintf("%.2fs", time.Since(start).Seconds()))
 	}()
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
- have updated it to use Lstat instead

## Summary by Sourcery

Improve build and development workflows by embedding version info, consolidating and enhancing Runfile tasks, adding offline support and execution timing to nix shell, fixing symlink checks, and passing version to Docker builds in CI.

New Features:
- Embed version metadata into built binaries via ldflags and build arguments

Bug Fixes:
- Switch from os.Stat to os.Lstat to correctly detect dangling symlinks in the executor

Enhancements:
- Require a version environment variable in Runfile tasks and consolidate build commands
- Add --offline flag to nix develop commands
- Log shell execution duration in nix Shell method
- Echo build success within the build task

Build:
- Refactor Runfile.yml to use shared build task with version injection
- Update Dockerfile.build to accept VERSION via build-arg

CI:
- Pass VERSION build argument to Docker build step in the GitHub Actions release workflow