### PR TITLE
ci: adds Version to nixy cli during build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           buildx_cache: "ghcr.io/${{ github.repository }}:buildx-cache-${{needs.github-release.outputs.sanitized_ref}}"
         run: |+
           docker buildx build -f ./Dockerfile.build \
-            --build-arg VERSION="${{ needs.github-release.outputs.version }}"
+            --build-arg VERSION="${{ needs.github-release.outputs.version }}" \
             --cache-to type=registry,ref="$buildx_cache",mode=max,compression=zstd,compression-level=13,force-compression=true \
             --cache-from type=registry,ref="$buildx_cache" \
             --cache-from type=registry,ref="$buildx_cache_master" \

--- a/Runfile.yml
+++ b/Runfile.yml
@@ -7,9 +7,7 @@ tasks:
     env:
       CGO_ENABLED: 0
     cmd:
-      - run: build
-        env:
-          version: "dev"
+      - run build version="$(echo \"dev built at $(date '+%X on %b %d, %4Y')\")"
 
   build:
     env:

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             # your packages here
             go
             nginx
+            coreutils
           ];
 
           shellHook = ''

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -176,6 +176,12 @@
               ln -sf ${pkgs.coreutils} /usr
             fi
 
+            # INFO: it seems like many tools have hardcoded value for /bin/sh, so we need to make sure that /bin/sh exists
+            if [ ! -e "/bin/sh" ]; then
+              mkdir -p /bin
+              ln -sf $(which bash) /bin/sh
+            fi
+
             if [ -n "${libraries}" ]; then
               export LD_LIBRARY_PATH="${libraries}:$LD_LIBRARY_PATH"
             fi


### PR DESCRIPTION
## Summary by Sourcery

Enhance the build process to embed version metadata into the Nixy CLI and ensure required shell and coreutils support in the Nix environment

Enhancements:
- Inject dynamic version string into builds by updating Runfile.yml and release workflow to pass VERSION build argument
- Ensure /bin/sh exists by symlinking bash and include coreutils in Nix flake workspace for tooling compatibility

Build:
- Pass VERSION build argument into Docker buildx in GitHub Actions release workflow