### PR TITLE
feat: workspace flake updates, and local executor mode updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ env:
 Built-in environment variables available:
 - `NIXY_OS` - Operating system (e.g., linux, darwin)
 - `NIXY_ARCH` - Architecture (e.g., amd64, arm64)
-- `NIXY_FULL_ARCH` - Full architecture string (e.g., x86_64)
+- `NIXY_ARCH_FULL` - Full architecture string (e.g., x86_64)
 
 ### 🔧 Build System
 Define reproducible builds:

--- a/pkg/nix/executor-local.go
+++ b/pkg/nix/executor-local.go
@@ -34,7 +34,7 @@ func UseLocal(ctx *Context, profile *Profile) (*ExecutorArgs, error) {
 
 		EnvVars: executorEnvVars{
 			User:     os.Getenv("USER"),
-			Home:     profile.FakeHomeDir,
+			Home:     os.Getenv("HOME"),
 			Term:     os.Getenv("TERM"),
 			TermInfo: os.Getenv("TERMINFO"),
 
@@ -46,7 +46,7 @@ func UseLocal(ctx *Context, profile *Profile) (*ExecutorArgs, error) {
 				filepath.Dir(nixPath),
 			},
 			NixyWorkspaceDir:      ctx.PWD,
-			NixyWorkspaceFlakeDir: ctx.PWD,
+			NixyWorkspaceFlakeDir: wsHostPath,
 			NixConfDir:            "",
 		},
 	}, nil

--- a/pkg/nix/nixy.go
+++ b/pkg/nix/nixy.go
@@ -263,7 +263,7 @@ func (nixy *Nixy) SyncToDisk() error {
 
 	nixy.Packages = upkg
 
-	b, err := yaml.Marshal(nixy)
+	b, err := yaml.Marshal(nixy.NixyConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -25,8 +25,6 @@ const (
 )
 
 func (nix *Nixy) writeWorkspaceFlake(ctx *Context) error {
-	shouldGenerate := false
-
 	input := WorkspaceFlakeGenParams{
 		NixPkgsDefaultCommit: nix.NixPkgs,
 		WorkspaceDirPath:     ctx.PWD,
@@ -40,19 +38,18 @@ func (nix *Nixy) writeWorkspaceFlake(ctx *Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to read from profile's nixy.yml: %w", err)
 		}
-		shouldGenerate = profileNix.hasHashChanged
+		nix.hasHashChanged = profileNix.hasHashChanged
 		input.Packages = append(input.Packages, profileNix.Packages...)
 		input.Libraries = append(input.Libraries, profileNix.Libraries...)
 	}
 
 	if nix.hasHashChanged {
-		shouldGenerate = true
 		input.Packages = append(input.Packages, nix.Packages...)
 		input.Libraries = append(input.Libraries, nix.Libraries...)
 		maps.Copy(input.Builds, nix.Builds)
 	}
 
-	if !shouldGenerate {
+	if !nix.hasHashChanged {
 		return nil
 	}
 

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -18,11 +18,13 @@
     {{- range $_, $v := $nixpkgsList }}
     nixpkgs_{{slice $v 0 7}}.url = "github:nixos/nixpkgs/{{$v}}";
     {{- end }}
+
+    nixpkgs-unstable.follows = "nixpkgs";
   };
 
   outputs = {
       self, nixpkgs, flake-utils,
-
+      nixpkgs-unstable,
       {{- range $_, $v := $nixpkgsList -}}
       nixpkgs_{{slice $v 0 7}},
       {{- end }}


### PR DESCRIPTION
## Summary by Sourcery

Refine workspace flake change detection, update local executor defaults, enhance flake template with unstable channel, rename a documentation env var, and serialize only the config section to disk.

Enhancements:
- Simplify workspace flake generation by using nix.hasHashChanged and remove redundant variable.
- Add nixpkgs-unstable channel and follow attribute in the workspace flake template.
- Configure local executor to use the real HOME environment variable and correct workspace flake directory path.
- Update SyncToDisk to marshal only the NixyConfig instead of the entire struct.

Documentation:
- Rename environment variable in README from NIXY_FULL_ARCH to NIXY_ARCH_FULL.