### PR TITLE
fix: nix develop profile issues

### DIFF
--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -112,7 +112,7 @@ func (n *Nixy) nixShellExec(ctx *Context, program string) (*exec.Cmd, error) {
 	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, nixFlakeProfileName)) {
 		scripts = append(scripts,
 			fmt.Sprintf("nix profile wipe-history --profile ./%s", nixFlakeProfileName),
-			fmt.Sprintf("nix develop --profile ./%s --command echo ''", nixFlakeProfileName),
+			fmt.Sprintf("nix develop --profile ./%s --command echo '' > /dev/null", nixFlakeProfileName),
 
 			// [READ about nix print-dev-env](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-print-dev-env)
 			fmt.Sprintf("nix print-dev-env ./%s > shell-init.sh", nixFlakeProfileName),

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -107,15 +107,10 @@ func (n *Nixy) nixShellExec(ctx *Context, program string) (*exec.Cmd, error) {
 		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
 	)
 
-	nixFlakeProfileName := "flake.profile"
-
-	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, nixFlakeProfileName)) {
+	if n.hasHashChanged {
 		scripts = append(scripts,
-			fmt.Sprintf("nix profile wipe-history --profile ./%s", nixFlakeProfileName),
-			fmt.Sprintf("nix develop --profile ./%s --command echo '' > /dev/null", nixFlakeProfileName),
-
 			// [READ about nix print-dev-env](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-print-dev-env)
-			fmt.Sprintf("nix print-dev-env ./%s > shell-init.sh", nixFlakeProfileName),
+			"nix print-dev-env ./ > shell-init.sh",
 		)
 	}
 

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -107,10 +107,15 @@ func (n *Nixy) nixShellExec(ctx *Context, program string) (*exec.Cmd, error) {
 		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
 	)
 
-	if n.hasHashChanged {
+	nixFlakeProfileName := "flake.profile"
+
+	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, nixFlakeProfileName)) {
 		scripts = append(scripts,
+			fmt.Sprintf("nix profile wipe-history --profile ./%s", nixFlakeProfileName),
+			fmt.Sprintf("nix develop --profile ./%s --command echo '' > /dev/null", nixFlakeProfileName),
+
 			// [READ about nix print-dev-env](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-print-dev-env)
-			"nix print-dev-env ./ > shell-init.sh",
+			fmt.Sprintf("nix print-dev-env ./%s > shell-init.sh", nixFlakeProfileName),
 		)
 	}
 

--- a/pkg/nix/shell.go
+++ b/pkg/nix/shell.go
@@ -107,15 +107,10 @@ func (n *Nixy) nixShellExec(ctx *Context, program string) (*exec.Cmd, error) {
 		fmt.Sprintf("cd %s", n.executorArgs.WorkspaceFlakeDirMountedPath),
 	)
 
-	nixFlakeProfileName := "flake.profile"
-
-	if n.hasHashChanged || !exists(filepath.Join(n.executorArgs.WorkspaceFlakeDirHostPath, nixFlakeProfileName)) {
+	if n.hasHashChanged {
 		scripts = append(scripts,
-			fmt.Sprintf("nix profile wipe-history --profile ./%s", nixFlakeProfileName),
-			fmt.Sprintf("nix develop --profile ./%s --command echo '' > /dev/null", nixFlakeProfileName),
-
 			// [READ about nix print-dev-env](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-print-dev-env)
-			fmt.Sprintf("nix print-dev-env ./%s > shell-init.sh", nixFlakeProfileName),
+			"nix print-dev-env . > shell-init.sh",
 		)
 	}
 

--- a/pkg/nix/templates/workspace-flake.nix.tpl
+++ b/pkg/nix/templates/workspace-flake.nix.tpl
@@ -168,7 +168,6 @@
 
           shellHook = ''
             {{- /* INFO: because glibcLocales is a linux only package, and causes nixy shell to break on macos */}}
-
             ${
               if pkgs.stdenv.isLinux
               then ''export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive''


### PR DESCRIPTION
Closes #20

- removes usage of `nix develop <profile>`
- updates it to use `nix print-dev-env`, which makes launching into shell much snappier and deterministic

## Summary by Sourcery

Replace the previous `nix develop --profile` workflow with a `nix print-dev-env` approach for faster and more deterministic shell launches, ensure profile hash changes are accumulated correctly, and add debug logging for flake file generation.

Enhancements:
- Replace `nix develop --profile` invocations with generating and sourcing a `shell-init.sh` via `nix print-dev-env`.
- Accumulate profile hash change flags instead of overwriting previous state.
- Add debug logs for skipping or writing `flake.nix` and the `shell-hook.sh` script.
- Clean up template whitespace in the workspace flake definition.