### PR TITLE
feat: adds git worktree check for workspace path

### DIFF
--- a/Runfile.yml
+++ b/Runfile.yml
@@ -14,15 +14,14 @@ tasks:
       CGO_ENABLED: 0
 
       binpath:
-        default: 
-          sh: "echo ./bin/nixy"
+        sh: "echo ./bin/nixy"
 
       GOOS:
-        default:
-          sh: go env GOOS
+        sh: go env GOOS
+
       GOARCH:
-        default:
-          sh: go env GOARCH
+        sh: go env GOARCH
+
       version:
         required: true
     cmd:

--- a/pkg/nixy/executor-bubblewrap.go
+++ b/pkg/nixy/executor-bubblewrap.go
@@ -30,6 +30,7 @@ func UseBubbleWrap(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, err
 			XDGDataHome:           filepath.Join(fakeHomeMountedPath, ".local", "share"),
 			NixyShell:             "true",
 			NixyWorkspaceDir:      ctx.PWD,
+			NixyWorkspaceLabel:    filepath.Base(ctx.PWD),
 			NixyWorkspaceFlakeDir: WorkspaceFlakeSandboxMountPath,
 			NixConfDir:            filepath.Join(runtimePaths.FakeHomeDir, ".config", "nix"),
 		},
@@ -50,6 +51,11 @@ func exists(path string) bool {
 }
 
 func (nixy *NixyWrapper) bubblewrapShell(ctx *Context, command string, args ...string) (*exec.Cmd, error) {
+	isWorktreeEnabled, workspaceDir, _ := GitWorktreeEnabledWorkspace(ctx, ctx.PWD)
+	if isWorktreeEnabled {
+		nixy.executorArgs.EnvVars.NixyWorkspaceLabel = filepath.Base(workspaceDir) + ctx.PWD[len(workspaceDir):]
+	}
+
 	bwrapArgs := []string{
 		// no-zombie processes
 		// "--clearenv",
@@ -94,10 +100,10 @@ func (nixy *NixyWrapper) bubblewrapShell(ctx *Context, command string, args ...s
 		"--bind", nixy.runtimePaths.NixDir, nixy.executorArgs.NixDirMountedPath,
 
 		// Current Working Directory as it is
-		"--bind", ctx.PWD, ctx.PWD,
+		"--bind", workspaceDir, workspaceDir,
 
 		// INFO: it is just to keep the workspace at /workspace in the sandbox
-		"--bind", ctx.PWD, WorkspaceDirSandboxMountPath,
+		"--bind", workspaceDir, WorkspaceDirSandboxMountPath,
 	}
 
 	// Mount terminfo if TERMINFO env var is set

--- a/pkg/nixy/executor-docker.go
+++ b/pkg/nixy/executor-docker.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"log/slog"
 )
 
 func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
@@ -28,6 +29,7 @@ func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) 
 			XDGCacheHome:          filepath.Join(fakeHomeMountedPath, ".cache"),
 			XDGDataHome:           filepath.Join(fakeHomeMountedPath, ".local", "share"),
 			NixyWorkspaceDir:      ctx.PWD,
+			NixyWorkspaceLabel:    filepath.Base(ctx.PWD),
 			NixyWorkspaceFlakeDir: WorkspaceFlakeSandboxMountPath,
 			NixConfDir:            filepath.Join(runtimePaths.FakeHomeDir, ".config", "nix"),
 		},
@@ -37,6 +39,11 @@ func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) 
 }
 
 func (nixy *NixyWrapper) dockerShell(ctx *Context, command string, args ...string) (*exec.Cmd, error) {
+	isWorktreeEnabled, workspaceDir, _ := GitWorktreeEnabledWorkspace(ctx, ctx.PWD)
+	if isWorktreeEnabled {
+		nixy.executorArgs.EnvVars.NixyWorkspaceLabel = filepath.Base(workspaceDir) + ctx.PWD[len(workspaceDir):]
+	}
+
 	addMount := func(src, dest string, flags ...string) string {
 		return fmt.Sprintf("%s:%s:%s", src, dest, strings.Join(flags, ","))
 	}
@@ -68,8 +75,8 @@ func (nixy *NixyWrapper) dockerShell(ctx *Context, command string, args ...strin
 		"-v", addMount(nixy.runtimePaths.NixDir, nixy.executorArgs.NixDirMountedPath, "z"),
 
 		// STEP: project dir
-		"-v", addMount(nixy.PWD, nixy.PWD, "Z"),
-		"-v", addMount(nixy.PWD, WorkspaceDirSandboxMountPath, "Z"),
+		"-v", addMount(workspaceDir, workspaceDir, "Z"),
+		"-v", addMount(workspaceDir, WorkspaceDirSandboxMountPath, "Z"),
 	}
 
 	// Mount terminfo if TERMINFO env var is set
@@ -101,6 +108,9 @@ func (nixy *NixyWrapper) dockerShell(ctx *Context, command string, args ...strin
 	dockerCmd = append(dockerCmd, "--rm", "-it", "gcr.io/distroless/static-debian12")
 	dockerCmd = append(dockerCmd, command)
 	dockerCmd = append(dockerCmd, args...)
+
+	slog.Info("HERE ...", "docker-cmd", dockerCmd)
+
 
 	return exec.CommandContext(ctx, dockerCmd[0], dockerCmd[1:]...), nil
 }

--- a/pkg/nixy/executor-docker.go
+++ b/pkg/nixy/executor-docker.go
@@ -82,17 +82,36 @@ func (nixy *NixyWrapper) dockerShell(ctx *Context, command string, args ...strin
 	// Mount terminfo if TERMINFO env var is set
 	if terminfo := os.Getenv("TERMINFO"); terminfo != "" {
 		dockerCmd = append(dockerCmd,
-			"--tmpfs", nixy.executorArgs.EnvVars.TermInfo,
 			"-v", addMount(terminfo, nixy.executorArgs.EnvVars.TermInfo, "ro", "z"),
 		)
 	}
 
-	for _, mount := range nixy.Mounts {
+	mounts := nixy.Mounts
+	if ctx.NixyUseProfile {
+		mounts = append(mounts, nixy.profileNixy.Mounts...)
+	}
+
+	nixyShellEnvExpander := func(key string) string {
+		slog.Info("nixy profile", "env", nixy.profileNixy.Env)
+		if v, ok := nixy.profileNixy.Env[key]; ok {
+			return os.ExpandEnv(v)
+		}
+
+		switch key {
+			case "HOME":
+				return nixy.executorArgs.FakeHomeMountedPath
+			default:
+				return ""
+		}
+	}
+
+	for _, mount := range mounts {
 		attrs := []string{"z"}
 		if mount.ReadOnly {
 			attrs = append(attrs, "ro")
 		}
-		dockerCmd = append(dockerCmd, "-v", addMount(mount.Source, mount.Destination, attrs...))
+
+		dockerCmd = append(dockerCmd, "-v", addMount(os.ExpandEnv(mount.Source), os.Expand(mount.Destination, nixyShellEnvExpander), attrs...))
 	}
 
 	for k, v := range nixy.executorArgs.EnvVars.toMap(ctx) {

--- a/pkg/nixy/executor-local.go
+++ b/pkg/nixy/executor-local.go
@@ -46,13 +46,19 @@ func UseLocal(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 			// 	filepath.Dir(nixPath),
 			// },
 			NixyWorkspaceDir:      ctx.PWD,
+			NixyWorkspaceLabel:    filepath.Base(ctx.PWD),
 			NixyWorkspaceFlakeDir: wsHostPath,
 			NixConfDir:            "",
 		},
 	}, nil
 }
 
-func (nix *NixyWrapper) localShell(ctx *Context, command string, args ...string) (*exec.Cmd, error) {
+func (nixy *NixyWrapper) localShell(ctx *Context, command string, args ...string) (*exec.Cmd, error) {
+	isWorktreeEnabled, workspaceDir, _ := GitWorktreeEnabledWorkspace(ctx, ctx.PWD)
+	if isWorktreeEnabled {
+		nixy.executorArgs.EnvVars.NixyWorkspaceLabel = filepath.Base(workspaceDir) + ctx.PWD[len(workspaceDir):]
+	}
+
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s:%s", filepath.Dir(ctx.NixyBinPath), os.Getenv("PATH")))
 	return cmd, nil

--- a/pkg/nixy/executor.go
+++ b/pkg/nixy/executor.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"log/slog"
+	"context"
+	"bytes"
 )
 
 func XDGDataDir() string {
@@ -15,6 +18,38 @@ func XDGDataDir() string {
 	}
 
 	return filepath.Join(xdgDataHome, "nixy")
+}
+
+// GitWorktreeEnabledWorkspace returns workspace path that needs to be 
+// used/mounted in an executor for a functional git bare repository experience
+func GitWorktreeEnabledWorkspace(ctx context.Context, dir string) (bool, string, error) {
+	workspaceDir := dir
+
+	gitDir, err := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir").CombinedOutput()
+	gitDir = bytes.TrimSpace(gitDir)
+	if err != nil {
+		slog.Debug("[CHECK/git-bare-repository] git-common-dir (FAILED)", "stderr", string(gitDir), "err", err)
+    return false, workspaceDir, err
+  }
+
+	slog.Debug("[CHECK/git-bare-repository] git-common-dir", "dir", string(gitDir))
+
+	gitBareRepoResult, err := exec.CommandContext(ctx, "git", "--git-dir", string(gitDir), "rev-parse", "--is-bare-repository").CombinedOutput()
+	gitBareRepoResult = bytes.TrimSpace(gitBareRepoResult)
+	if err != nil {
+		slog.Error("[CHECK/git-bare-repository] is-bare-repository (FAILED)", "stderr", string(gitBareRepoResult), "err", err) 
+    return false, workspaceDir, err
+  }
+
+	isWorktree := false
+	if string(gitBareRepoResult) == "true" {
+		isWorktree = true
+		workspaceDir = string(gitDir)
+	}
+
+	slog.Debug("[CHECK/git-bare-repository]", "workspace-path", workspaceDir)
+
+	return isWorktree, workspaceDir, nil
 }
 
 func (nixy *NixyWrapper) PrepareShellCommand(ctx *Context, command string, args ...string) (*exec.Cmd, error) {
@@ -53,6 +88,11 @@ type executorEnvVars struct {
 
 	NixyShell             string `json:"NIXY_SHELL"`
 	NixyWorkspaceDir      string `json:"NIXY_WORKSPACE_DIR"`
+
+	// NixyWorkspaceLabel is just a display only alias for NIXY_WORKSPACE_DIR
+	// It comes useful in cases of git worktree integrations
+	NixyWorkspaceLabel      string `json:"NIXY_WORKSPACE_LABEL"`
+
 	NixyWorkspaceFlakeDir string `json:"NIXY_WORKSPACE_FLAKE_DIR"`
 	NixyBuildHook         string `json:"NIXY_BUILD_HOOK"`
 	NixConfDir            string `json:"NIX_CONF_DIR"`
@@ -75,6 +115,7 @@ func (e *executorEnvVars) toMap(ctx *Context) map[string]string {
 
 		"NIXY_SHELL":               "true",
 		"NIXY_WORKSPACE_DIR":       e.NixyWorkspaceDir,
+		"NIXY_WORKSPACE_LABEL":     e.NixyWorkspaceLabel,
 		"NIXY_WORKSPACE_FLAKE_DIR": e.NixyWorkspaceFlakeDir,
 		"NIXY_BUILD_HOOK":          e.NixyBuildHook,
 	}


### PR DESCRIPTION
This allows the entire git bare repository to be mounted in bubblewrap/docker executor when inside a git worktree, otherwise, only the branch is mounted, which gets treated as a regular directory in `nixy shell`

Closes #28

## Summary by Sourcery

Add git worktree-aware workspace handling so executors mount the correct directory when running in a bare-repo worktree.

New Features:
- Introduce detection of git common directory and bare-repository state to derive a worktree-aware workspace path for executors.
- Expose a NIXY_WORKSPACE_LABEL environment variable to distinguish display labels from the actual workspace directory path.

Enhancements:
- Update local, Docker, and bubblewrap executors to use the git worktree-aware workspace path for mounts and to adjust workspace labels accordingly.
- Simplify Runfile build variable definitions for binpath, GOOS, and GOARCH by removing nested defaults.