### PR TITLE
feat: now nixy keeps generates flake.nix and other templates in project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Nixy writes generated workspace files to the project-local `.nixy/` directory:
 - `.nixy/flake.lock` - generated lock file for the workspace flake
 - `.nixy/shell-enter.sh` - generated script from `onShellEnter`
 - `.nixy/shell-env.sh` - generated environment from `nix print-dev-env`
-- `.nixy/build.<target>.sh` - generated build script for a target
+- `.nixy/build.<target>.sh` - generated build script for a target (`/` and `:` are replaced with `_`)
 - `.nixy/config.hash` - hash used to decide when generated files need refreshing
 
 Build outputs remain under each build target directory, for example `<build.dir>/.nixy/dist`.

--- a/README.md
+++ b/README.md
@@ -120,16 +120,22 @@ Download and install packages directly from URLs with environment variable expan
 ```yaml
 packages:
   - name: kubectl
-    url: https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl
-    sha256: "abc123..."  # Optional, auto-fetched if not provided
-    
+    sources:
+      linux/amd64:
+        url: https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl
+        sha256: "abc123..."  # Optional, auto-fetched if not provided
+     
   - name: terraform
-    url: https://releases.hashicorp.com/terraform/1.6.0/terraform_1.6.0_linux_amd64.zip
+    sources:
+      linux/amd64:
+        url: https://releases.hashicorp.com/terraform/1.6.0/terraform_1.6.0_linux_amd64.zip
     # Automatically detects archive type and extracts
-    
+     
   # Environment variables are expanded in URLs
   - name: my-tool
-    url: https://github.com/org/tool/releases/download/v${MY_VERSION}/tool-${NIXY_OS}-${NIXY_ARCH}.tar.gz
+    sources:
+      linux/amd64:
+        url: https://github.com/org/tool/releases/download/v${MY_VERSION}/tool-${NIXY_OS}-${NIXY_ARCH}.tar.gz
     # Uses MY_VERSION from env section and built-in NIXY_* vars
 
 env:
@@ -260,7 +266,8 @@ NIXY_EXECUTOR=bubblewrap nixy shell
 ### 👤 Profile Management
 
 > [!NOTE]
-> Profiles provide file system isolation. Different dev shells within the same profile share some filesystems like nix-store, fake-home, etc.
+> Profiles provide runtime isolation. Different dev shells within the same profile share runtime filesystems like nix-store and fake-home.
+> Profile-level `nixy.yml` config is loaded only when `NIXY_USE_PROFILE=true`.
 
 Keep separate development profiles:
 ```bash
@@ -273,6 +280,9 @@ NIXY_PROFILE=work nixy shell
 
 # List profiles
 nixy profile list
+
+# Edit profile config
+nixy profile edit work
 ```
 
 ## Advanced Features
@@ -288,7 +298,9 @@ packages:
   - nodejs                    # From default nixpkgs
   - older#python311           # Python from older nixpkgs version
   - name: custom-tool
-    url: https://example.com/tool.tar.gz
+    sources:
+      linux/amd64:
+        url: https://example.com/tool.tar.gz
 ```
 
 ### 🗂️ Smart Archive Packages Handling
@@ -307,6 +319,19 @@ All execution backends provide pure, reproducible environments with:
 - Configuration change detection via SHA256
 - Rebuilds only when necessary
 - Fast subsequent shells
+
+### 🔎 Inspectable Generated Files
+Nixy writes generated workspace files to the project-local `.nixy/` directory:
+
+- `.nixy/flake.nix` - generated Nix flake used for the shell/build environment
+- `.nixy/flake.lock` - generated lock file for the workspace flake
+- `.nixy/shell-enter.sh` - generated script from `onShellEnter`
+- `.nixy/shell-env.sh` - generated environment from `nix print-dev-env`
+- `.nixy/build.<target>.sh` - generated build script for a target
+- `.nixy/config.hash` - hash used to decide when generated files need refreshing
+
+Build outputs remain under each build target directory, for example `<build.dir>/.nixy/dist`.
+`.nixy/` should be gitignored because these files are regenerated from `nixy.yml`.
 
 ### 🎨 Environment Customization
 ```yaml
@@ -339,13 +364,9 @@ mounts:
 - `nixy shell:hook <shell>` - Output shell hook script for auto-activation (supports: bash, zsh, fish)
 
 ### Profile Commands
-- `nixy profile create <name>` - Create new profile
+- `nixy profile create <name>` - Create a profile namespace
+- `nixy profile edit [name]` - Edit profile-level config
 - `nixy profile list` - List all profiles
-- `nixy profile remove <name>` - Remove profile
-
-### Utility Commands
-- `nixy validate` - Validate nixy.yml
-- `nixy version` - Show version information
 
 ## Examples
 
@@ -365,7 +386,9 @@ packages:
 
   # Tools
   - name: stripe-cli
-    url: https://github.com/stripe/stripe-cli/releases/download/v1.19.1/stripe_1.19.1_linux_x86_64.tar.gz
+    sources:
+      linux/amd64:
+        url: https://github.com/stripe/stripe-cli/releases/download/v1.19.1/stripe_1.19.1_linux_x86_64.tar.gz
 
 libraries:
   - postgresql
@@ -402,11 +425,17 @@ packages:
   
   # Kubernetes tools
   - name: kubectl
-    url: https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl
+    sources:
+      linux/amd64:
+        url: https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl
   - name: helm
-    url: https://get.helm.sh/helm-v3.13.0-linux-amd64.tar.gz
+    sources:
+      linux/amd64:
+        url: https://get.helm.sh/helm-v3.13.0-linux-amd64.tar.gz
   - name: k9s
-    url: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
+    sources:
+      linux/amd64:
+        url: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
 
 onShellEnter: |
   export KUBECONFIG=$HOME/.kube/config
@@ -427,9 +456,14 @@ packages:
   - <package-name>                    # Simple package (uses default)
   - <key>#<package>                   # From specific nixpkgs key
   - name: <name>                      # URL package
-    url: <url>
-    sha256: <hash>                    # Optional
-    type: binary|archive              # Auto-detected
+    sources:
+      linux/amd64:
+        url: <url>
+        sha256: <hash>                # Optional
+    binPaths:
+      - <relative-bin-dir>            # Optional
+    installHook: |                    # Optional
+      <shell commands>
 
 # System libraries
 libraries:
@@ -467,7 +501,8 @@ builds:
 ## Environment Variables
 
 - `NIXY_EXECUTOR` - Execution backend (local, local-ignore-env, docker, bubblewrap)
-- `NIXY_PROFILE`  - Profile name to use
+- `NIXY_PROFILE` - Profile namespace to use
+- `NIXY_USE_PROFILE` - Load profile-level config when set to `true` or `1`
 
 ## Troubleshooting
 

--- a/pkg/nixy/build.go
+++ b/pkg/nixy/build.go
@@ -7,9 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/nxtcoder17/nixy/pkg/nixy/templates"
 )
+
+func buildScriptFileName(target string) string {
+	safeTarget := strings.NewReplacer("/", "_", "\\", "_").Replace(target)
+	return fmt.Sprintf("build.%s.sh", safeTarget)
+}
 
 func (nixy *NixyWrapper) Build(ctx *Context, target string) error {
 	build, ok := nixy.Builds[target]
@@ -17,7 +23,7 @@ func (nixy *NixyWrapper) Build(ctx *Context, target string) error {
 		return fmt.Errorf("build target (%s) does not exist", target)
 	}
 
-	b, err := templates.RenderBuildHook(templates.BuildHookParams{
+	b, err := templates.RenderBuildScript(templates.BuildHookParams{
 		WorkDir:     build.BuildDir(ctx.PWD),
 		BuildTarget: target,
 		OutputDir:   build.OutputDir(ctx.PWD),
@@ -28,11 +34,12 @@ func (nixy *NixyWrapper) Build(ctx *Context, target string) error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(nixy.executorArgs.WorkspaceFlakeDirHostPath, buildHookFileName), b, 0o644); err != nil {
+	buildScript := buildScriptFileName(target)
+	if err := os.WriteFile(filepath.Join(nixy.executorArgs.WorkspaceFlakeDirHostPath, buildScript), b, 0o644); err != nil {
 		return err
 	}
 
-	nixy.executorArgs.EnvVars.NixyBuildHook = "true"
+	nixy.executorArgs.EnvVars.NixyBuildHook = buildScript
 
 	cmd, err := nixy.nixShellExec(ctx, "echo build successfull")
 	if err != nil {
@@ -58,7 +65,7 @@ func (n *InShellNixy) Build(ctx context.Context, target string) error {
 		return fmt.Errorf("build target (%s) does not exist", target)
 	}
 
-	b, err := templates.RenderBuildHook(templates.BuildHookParams{
+	b, err := templates.RenderBuildScript(templates.BuildHookParams{
 		WorkDir:     build.BuildDir(n.PWD),
 		BuildTarget: target,
 		OutputDir:   build.OutputDir(n.PWD),
@@ -74,7 +81,7 @@ func (n *InShellNixy) Build(ctx context.Context, target string) error {
 		return fmt.Errorf("NIXY_WORKSPACE_FLAKE_DIR must be set in a nixy shell")
 	}
 
-	buildHookScript := filepath.Join(wsFlakeDir, buildHookFileName)
+	buildHookScript := filepath.Join(wsFlakeDir, buildScriptFileName(target))
 
 	if err := os.WriteFile(buildHookScript, b, 0o644); err != nil {
 		return err

--- a/pkg/nixy/build.go
+++ b/pkg/nixy/build.go
@@ -13,8 +13,8 @@ import (
 )
 
 func buildScriptFileName(target string) string {
-	safeTarget := strings.NewReplacer("/", "_", "\\", "_").Replace(target)
-	return fmt.Sprintf("build.%s.sh", safeTarget)
+	target = strings.NewReplacer("/", "_", ":", "_").Replace(target)
+	return fmt.Sprintf("build.%s.sh", target)
 }
 
 func (nixy *NixyWrapper) Build(ctx *Context, target string) error {
@@ -39,7 +39,7 @@ func (nixy *NixyWrapper) Build(ctx *Context, target string) error {
 		return err
 	}
 
-	nixy.executorArgs.EnvVars.NixyBuildHook = buildScript
+	nixy.executorArgs.EnvVars.NixyBuildScript = buildScript
 
 	cmd, err := nixy.nixShellExec(ctx, "echo build successfull")
 	if err != nil {

--- a/pkg/nixy/constants.go
+++ b/pkg/nixy/constants.go
@@ -1,9 +1,6 @@
 package nixy
 
 import (
-	"crypto/md5"
-	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -14,16 +11,8 @@ func profilePath(profile string) string {
 	return filepath.Join(profileBasePath, profile)
 }
 
-func flakeDirPath(profile string) string {
-	pwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	h := md5.New()
-	h.Write([]byte(pwd))
-
-	return filepath.Join(profilePath(profile), "workspaces", fmt.Sprintf("%x-%s", h.Sum(nil), filepath.Base(pwd)))
+func workspaceNixyDir(workspaceDir string) string {
+	return filepath.Join(workspaceDir, ".nixy")
 }
 
 var osArchEnv = map[string]string{

--- a/pkg/nixy/constants.go
+++ b/pkg/nixy/constants.go
@@ -11,7 +11,7 @@ func profilePath(profile string) string {
 	return filepath.Join(profileBasePath, profile)
 }
 
-func workspaceNixyDir(workspaceDir string) string {
+func workspaceNixyDirPath(workspaceDir string) string {
 	return filepath.Join(workspaceDir, ".nixy")
 }
 

--- a/pkg/nixy/executor-bubblewrap.go
+++ b/pkg/nixy/executor-bubblewrap.go
@@ -18,7 +18,7 @@ func UseBubbleWrap(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, err
 		FakeHomeMountedPath:          fakeHomeMountedPath,
 		NixDirMountedPath:            "/nix",
 		WorkspaceFlakeDirMountedPath: WorkspaceFlakeSandboxMountPath,
-		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(runtimePaths.WorkspacesDir, ctx.PWD),
+		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(ctx.PWD),
 
 		EnvVars: executorEnvVars{
 			User:                  "nixy",

--- a/pkg/nixy/executor-bubblewrap.go
+++ b/pkg/nixy/executor-bubblewrap.go
@@ -11,6 +11,7 @@ import (
 
 func UseBubbleWrap(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 	fakeHomeMountedPath := "/home/nixy"
+	wsHostPath := runtimePaths.WorkspaceNixyDir
 
 	bwrap := ExecutorArgs{
 		NixBinaryMountedPath:         "/nix/bin/nix",
@@ -18,7 +19,7 @@ func UseBubbleWrap(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, err
 		FakeHomeMountedPath:          fakeHomeMountedPath,
 		NixDirMountedPath:            "/nix",
 		WorkspaceFlakeDirMountedPath: WorkspaceFlakeSandboxMountPath,
-		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(ctx.PWD),
+		WorkspaceFlakeDirHostPath:    wsHostPath,
 
 		EnvVars: executorEnvVars{
 			User:                  "nixy",

--- a/pkg/nixy/executor-docker.go
+++ b/pkg/nixy/executor-docker.go
@@ -11,6 +11,7 @@ import (
 
 func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 	fakeHomeMountedPath := "/home/nixy"
+	wsHostPath := runtimePaths.WorkspaceNixyDir
 
 	dockerCfg := ExecutorArgs{
 		NixBinaryMountedPath:         "/nixy/nix",
@@ -18,7 +19,7 @@ func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) 
 		FakeHomeMountedPath:          fakeHomeMountedPath,
 		NixDirMountedPath:            "/nix",
 		WorkspaceFlakeDirMountedPath: WorkspaceFlakeSandboxMountPath,
-		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(ctx.PWD),
+		WorkspaceFlakeDirHostPath:    wsHostPath,
 
 		EnvVars: executorEnvVars{
 			User:                  "nixy",

--- a/pkg/nixy/executor-docker.go
+++ b/pkg/nixy/executor-docker.go
@@ -18,7 +18,7 @@ func UseDocker(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) 
 		FakeHomeMountedPath:          fakeHomeMountedPath,
 		NixDirMountedPath:            "/nix",
 		WorkspaceFlakeDirMountedPath: WorkspaceFlakeSandboxMountPath,
-		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(runtimePaths.WorkspacesDir, ctx.PWD),
+		WorkspaceFlakeDirHostPath:    deriveWorkspacePath(ctx.PWD),
 
 		EnvVars: executorEnvVars{
 			User:                  "nixy",

--- a/pkg/nixy/executor-local.go
+++ b/pkg/nixy/executor-local.go
@@ -8,10 +8,6 @@ import (
 	"path/filepath"
 )
 
-func deriveWorkspacePath(cwd string) string {
-	return workspaceNixyDir(cwd)
-}
-
 func UseLocal(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 	nixPath, err := exec.LookPath("nix")
 	if err != nil {
@@ -20,7 +16,7 @@ func UseLocal(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 		}
 	}
 
-	wsHostPath := deriveWorkspacePath(ctx.PWD)
+	wsHostPath := runtimePaths.WorkspaceNixyDir
 
 	return &ExecutorArgs{
 		NixBinaryMountedPath:         nixPath,

--- a/pkg/nixy/executor-local.go
+++ b/pkg/nixy/executor-local.go
@@ -1,7 +1,6 @@
 package nixy
 
 import (
-	"crypto/md5"
 	"errors"
 	"fmt"
 	"os"
@@ -9,9 +8,8 @@ import (
 	"path/filepath"
 )
 
-func deriveWorkspacePath(workspacesDir, cwd string) string {
-	sum := md5.Sum([]byte(cwd))
-	return filepath.Join(workspacesDir, fmt.Sprintf("%x-%s", sum, filepath.Base(cwd)))
+func deriveWorkspacePath(cwd string) string {
+	return workspaceNixyDir(cwd)
 }
 
 func UseLocal(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
@@ -22,7 +20,7 @@ func UseLocal(ctx *Context, runtimePaths *RuntimePaths) (*ExecutorArgs, error) {
 		}
 	}
 
-	wsHostPath := deriveWorkspacePath(runtimePaths.WorkspacesDir, ctx.PWD)
+	wsHostPath := deriveWorkspacePath(ctx.PWD)
 
 	return &ExecutorArgs{
 		NixBinaryMountedPath:         nixPath,

--- a/pkg/nixy/executor.go
+++ b/pkg/nixy/executor.go
@@ -79,7 +79,7 @@ type executorEnvVars struct {
 	NixyGitRoot string `json:"NIXY_GIT_ROOT"`
 
 	NixyWorkspaceFlakeDir string `json:"NIXY_WORKSPACE_FLAKE_DIR"`
-	NixyBuildHook         string `json:"NIXY_BUILD_HOOK"`
+	NixyBuildScript       string `json:"NIXY_BUILD_SCRIPT"`
 	NixConfDir            string `json:"NIX_CONF_DIR"`
 }
 
@@ -102,7 +102,7 @@ func (e *executorEnvVars) toMap(ctx *Context) map[string]string {
 		"NIXY_WORKSPACE_DIR":       e.NixyWorkspaceDir,
 		"NIXY_GIT_ROOT":            e.NixyGitRoot,
 		"NIXY_WORKSPACE_FLAKE_DIR": e.NixyWorkspaceFlakeDir,
-		"NIXY_BUILD_HOOK":          e.NixyBuildHook,
+		"NIXY_BUILD_SCRIPT":        e.NixyBuildScript,
 	}
 
 	if e.NixConfDir != "" {

--- a/pkg/nixy/nixy.go
+++ b/pkg/nixy/nixy.go
@@ -270,9 +270,12 @@ func LoadFromFile(parent context.Context, f string) (*NixyWrapper, error) {
 		return nil, err
 	}
 
-	hasHashChanged, err := compareAndSaveHash(filepath.Join(flakeDirPath(ctx.NixyProfile), "nixy.yml.sha256"), nc.sha256Sum)
+	hasHashChanged, err := compareAndSaveHash(filepath.Join(workspaceNixyDir(ctx.PWD), configHashFileName), nc.sha256Sum)
 	if err != nil {
 		return nil, err
+	}
+	if !hasHashChanged && !workspaceGeneratedFilesExist(workspaceNixyDir(ctx.PWD)) {
+		hasHashChanged = true
 	}
 
 	nixy := NixyWrapper{
@@ -296,7 +299,7 @@ func LoadFromFile(parent context.Context, f string) (*NixyWrapper, error) {
 		if err != nil {
 			return nil, err
 		}
-		hasChanged, err := compareAndSaveHash(filepath.Join(profilePath(ctx.NixyProfile), "nixy.yml.sha256"), nc.sha256Sum)
+		hasChanged, err := compareAndSaveHash(filepath.Join(profilePath(ctx.NixyProfile), configHashFileName), nc.sha256Sum)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/nixy/nixy.go
+++ b/pkg/nixy/nixy.go
@@ -265,16 +265,16 @@ func LoadFromFile(parent context.Context, f string) (*NixyWrapper, error) {
 	}
 
 	// Always create runtime paths (needed for workspace flake storage)
-	runtimePaths, err := NewRuntimePaths(ctx.NixyProfile)
+	runtimePaths, err := NewRuntimePaths(ctx.NixyProfile, ctx.PWD)
 	if err != nil {
 		return nil, err
 	}
 
-	hasHashChanged, err := compareAndSaveHash(filepath.Join(workspaceNixyDir(ctx.PWD), configHashFileName), nc.sha256Sum)
+	hasHashChanged, err := compareAndSaveHash(filepath.Join(runtimePaths.WorkspaceNixyDir, configHashFileName), nc.sha256Sum)
 	if err != nil {
 		return nil, err
 	}
-	if !hasHashChanged && !workspaceGeneratedFilesExist(workspaceNixyDir(ctx.PWD)) {
+	if !hasHashChanged && !workspaceGeneratedFilesExist(runtimePaths.WorkspaceNixyDir) {
 		hasHashChanged = true
 	}
 

--- a/pkg/nixy/runtime_paths.go
+++ b/pkg/nixy/runtime_paths.go
@@ -11,6 +11,7 @@ import (
 type RuntimePaths struct {
 	Name             string // profile name (used for directory organization)
 	BasePath         string // ~/.local/share/nixy/profiles/<name>
+	WorkspaceNixyDir string // project-local .nixy directory, when a workspace is available
 	FakeHomeDir      string // fake home directory for sandboxing
 	NixDir           string // nix store directory
 	StaticNixBinPath string // path to static nix binary
@@ -18,14 +19,19 @@ type RuntimePaths struct {
 
 // NewRuntimePaths creates and initializes the runtime paths for a given profile name.
 // This is always called regardless of NIXY_USE_PROFILE setting.
-func NewRuntimePaths(name string) (*RuntimePaths, error) {
+func NewRuntimePaths(name string, workspaceDir ...string) (*RuntimePaths, error) {
 	basePath := filepath.Join(XDGDataDir(), "profiles", name)
 	nixDir := filepath.Join(basePath, "nix")
 	fakeHomeDir := filepath.Join(basePath, "fake-home")
+	workspaceNixyDir := ""
+	if len(workspaceDir) > 0 && workspaceDir[0] != "" {
+		workspaceNixyDir = workspaceNixyDirPath(workspaceDir[0])
+	}
 
 	rp := &RuntimePaths{
 		Name:             name,
 		BasePath:         basePath,
+		WorkspaceNixyDir: workspaceNixyDir,
 		FakeHomeDir:      fakeHomeDir,
 		NixDir:           nixDir,
 		StaticNixBinPath: filepath.Join(nixDir, "bin", "nix"),
@@ -42,6 +48,7 @@ func NewRuntimePaths(name string) (*RuntimePaths, error) {
 func (rp *RuntimePaths) CreateDirs() error {
 	dirs := []string{
 		rp.BasePath,
+		rp.WorkspaceNixyDir,
 		rp.FakeHomeDir,
 		filepath.Dir(rp.StaticNixBinPath),
 		// we need to have this nix dir to be used for nix store
@@ -50,6 +57,9 @@ func (rp *RuntimePaths) CreateDirs() error {
 	}
 
 	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}

--- a/pkg/nixy/runtime_paths.go
+++ b/pkg/nixy/runtime_paths.go
@@ -11,7 +11,6 @@ import (
 type RuntimePaths struct {
 	Name             string // profile name (used for directory organization)
 	BasePath         string // ~/.local/share/nixy/profiles/<name>
-	WorkspacesDir    string // directory for workspace flakes
 	FakeHomeDir      string // fake home directory for sandboxing
 	NixDir           string // nix store directory
 	StaticNixBinPath string // path to static nix binary
@@ -27,7 +26,6 @@ func NewRuntimePaths(name string) (*RuntimePaths, error) {
 	rp := &RuntimePaths{
 		Name:             name,
 		BasePath:         basePath,
-		WorkspacesDir:    filepath.Join(basePath, "workspaces"),
 		FakeHomeDir:      fakeHomeDir,
 		NixDir:           nixDir,
 		StaticNixBinPath: filepath.Join(nixDir, "bin", "nix"),
@@ -44,7 +42,6 @@ func NewRuntimePaths(name string) (*RuntimePaths, error) {
 func (rp *RuntimePaths) CreateDirs() error {
 	dirs := []string{
 		rp.BasePath,
-		rp.WorkspacesDir,
 		rp.FakeHomeDir,
 		filepath.Dir(rp.StaticNixBinPath),
 		// we need to have this nix dir to be used for nix store

--- a/pkg/nixy/shell.go
+++ b/pkg/nixy/shell.go
@@ -15,9 +15,19 @@ import (
 )
 
 const (
-	shellHookFileName = "shell-hook.sh"
-	buildHookFileName = "build-hook.sh"
+	shellEnterFileName = "shell-enter.sh"
+	shellEnvFileName   = "shell-env.sh"
+	configHashFileName = "config.hash"
 )
+
+func workspaceGeneratedFilesExist(dir string) bool {
+	for _, file := range []string{"flake.nix", shellEnterFileName, shellEnvFileName} {
+		if !exists(filepath.Join(dir, file)) {
+			return false
+		}
+	}
+	return true
+}
 
 // getProfilePackages returns profile packages if NIXY_USE_PROFILE is enabled
 func (n *NixyWrapper) getProfilePackages(ctx *Context) []*NormalizedPackage {
@@ -83,16 +93,16 @@ func (nix *NixyWrapper) writeWorkspaceFlake(
 		return err
 	}
 
-	shellHook, err := templates.RenderShellHook(templates.ShellHookParams{
+	shellHook, err := templates.RenderShellEnter(templates.ShellHookParams{
 		OnShellEnter: nix.OnShellEnter,
 	})
 	if err != nil {
 		return err
 	}
 
-	slog.Debug("writing shell-hook.sh")
-	if err := os.WriteFile(filepath.Join(nix.executorArgs.WorkspaceFlakeDirHostPath, "shell-hook.sh"), []byte(shellHook), 0o744); err != nil {
-		return fmt.Errorf("failed to write shell-hook.sh: %w", err)
+	slog.Debug("writing shell-enter.sh")
+	if err := os.WriteFile(filepath.Join(nix.executorArgs.WorkspaceFlakeDirHostPath, shellEnterFileName), []byte(shellHook), 0o744); err != nil {
+		return fmt.Errorf("failed to write shell-enter.sh: %w", err)
 	}
 
 	flake, err := templates.RenderWorkspaceFlake(flakeParams)
@@ -161,11 +171,11 @@ func (n *NixyWrapper) nixShellExec(ctx *Context, program string) (*exec.Cmd, err
 	if n.hasHashChanged {
 		scripts = append(scripts,
 			// [READ about nix print-dev-env](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-print-dev-env)
-			"nix print-dev-env . > shell-init.sh",
+			fmt.Sprintf("nix print-dev-env path:. > %s", shellEnvFileName),
 		)
 	}
 
-	scripts = append(scripts, "source shell-init.sh")
+	scripts = append(scripts, fmt.Sprintf("source %s", shellEnvFileName))
 	scripts = append(scripts, "exec "+program)
 
 	nixShell := []string{"shell"}

--- a/pkg/nixy/templates/build.sh.tpl
+++ b/pkg/nixy/templates/build.sh.tpl
@@ -1,4 +1,4 @@
-{{- define "build-hook" }}
+{{- define "build" }}
 
 {{- $projectDir := .WorkDir -}}
 {{- $buildTarget := .BuildTarget -}}
@@ -17,18 +17,22 @@ cd "$workspace_dir"
 {{- end }}
 
 {{- range $p := .CopyPaths }}
-mkdir -p $(dirname {{$p}})
-cp -r {{$projectDir}}/{{$p}} ./$(dirname {{$p}})
+mkdir -p "$(dirname "{{$p}}")"
+cp -r "{{$projectDir}}/{{$p}}" "./$(dirname "{{$p}}")"
 {{- end }}
 
 dir="{{$outputDir}}"
 mkdir -p $dir
 
-nix build .#{{$buildTarget}} --no-link -o $dir/app
+nix build path:.#{{$buildTarget}} --no-link -o $dir/app
 readlink -f $dir/app > $dir/app-store-path
 
 {{- range $p := .CopyPaths }}
-rm -rf {{$p}}
+rm -rf "{{$p}}"
+parent_dir="$(dirname "{{$p}}")"
+if [ "$parent_dir" != "." ]; then
+  rmdir -p "$parent_dir" 2>/dev/null || true
+fi
 {{- end }}
 
 pushd $dir > /dev/null

--- a/pkg/nixy/templates/shell-enter.sh.tpl
+++ b/pkg/nixy/templates/shell-enter.sh.tpl
@@ -1,3 +1,3 @@
-{{- define "shell-hook" }}
+{{- define "shell-enter" }}
 {{- .OnShellEnter }}
 {{- end }}

--- a/pkg/nixy/templates/types.go
+++ b/pkg/nixy/templates/types.go
@@ -16,11 +16,11 @@ var profileNixyYamlContent string
 //go:embed workspace-flake.nix.tpl
 var wsFlakeContent string
 
-//go:embed shell-hook.sh.tpl
-var shellHookScript string
+//go:embed shell-enter.sh.tpl
+var shellEnterScript string
 
-//go:embed build-hook.sh.tpl
-var buildHookScript string
+//go:embed build.sh.tpl
+var buildScript string
 
 //go:embed nix.conf.tpl
 var nixConf string
@@ -63,12 +63,12 @@ func init() {
 		panic(fmt.Errorf("failed to parse workspace flake.nix: %w", err))
 	}
 
-	if _, err := t.Parse(shellHookScript); err != nil {
-		panic(fmt.Errorf("failed to parse shell hook script: %w", err))
+	if _, err := t.Parse(shellEnterScript); err != nil {
+		panic(fmt.Errorf("failed to parse shell enter script: %w", err))
 	}
 
-	if _, err := t.Parse(buildHookScript); err != nil {
-		panic(fmt.Errorf("failed to parse build hook script: %w", err))
+	if _, err := t.Parse(buildScript); err != nil {
+		panic(fmt.Errorf("failed to parse build script: %w", err))
 	}
 
 	if _, err := t.Parse(nixConf); err != nil {
@@ -137,10 +137,10 @@ type ShellHookParams struct {
 	OnShellEnter string
 }
 
-func RenderShellHook(params ShellHookParams) ([]byte, error) {
+func RenderShellEnter(params ShellHookParams) ([]byte, error) {
 	b := new(bytes.Buffer)
-	if err := t.ExecuteTemplate(b, "shell-hook", params); err != nil {
-		return nil, fmt.Errorf("failed to render shell-hook.sh: %w", err)
+	if err := t.ExecuteTemplate(b, "shell-enter", params); err != nil {
+		return nil, fmt.Errorf("failed to render shell-enter.sh: %w", err)
 	}
 
 	return b.Bytes(), nil
@@ -154,10 +154,10 @@ type BuildHookParams struct {
 	Command     string
 }
 
-func RenderBuildHook(params BuildHookParams) ([]byte, error) {
+func RenderBuildScript(params BuildHookParams) ([]byte, error) {
 	b := new(bytes.Buffer)
-	if err := t.ExecuteTemplate(b, "build-hook", params); err != nil {
-		return nil, fmt.Errorf("failed to render build-hook.sh: %w", err)
+	if err := t.ExecuteTemplate(b, "build", params); err != nil {
+		return nil, fmt.Errorf("failed to render build script: %w", err)
 	}
 
 	return b.Bytes(), nil

--- a/pkg/nixy/templates/workspace-flake.nix.tpl
+++ b/pkg/nixy/templates/workspace-flake.nix.tpl
@@ -210,12 +210,12 @@
             export {{$k}}="{{$v}}"
             {{- end }}
 
-            if [ -e shell-hook.sh ]; then
-              source "shell-hook.sh"
+            if [ -e shell-enter.sh ]; then
+              source "shell-enter.sh"
             fi
 
-            if [ "$NIXY_BUILD_HOOK" = "true" ] && [ -e build-hook.sh ]; then
-              source "build-hook.sh"
+            if [ -n "$NIXY_BUILD_HOOK" ] && [ -e "$NIXY_BUILD_HOOK" ]; then
+              source "$NIXY_BUILD_HOOK"
             fi
 
             cd {{$projectDir}}

--- a/pkg/nixy/templates/workspace-flake.nix.tpl
+++ b/pkg/nixy/templates/workspace-flake.nix.tpl
@@ -214,8 +214,8 @@
               source "shell-enter.sh"
             fi
 
-            if [ -n "$NIXY_BUILD_HOOK" ] && [ -e "$NIXY_BUILD_HOOK" ]; then
-              source "$NIXY_BUILD_HOOK"
+            if [ -n "$NIXY_BUILD_SCRIPT" ] && [ -e "$NIXY_BUILD_SCRIPT" ]; then
+              source "$NIXY_BUILD_SCRIPT"
             fi
 
             cd {{$projectDir}}


### PR DESCRIPTION
in .nixy directory for improved visbility and debugging

## Summary by Sourcery

Write generated flake, shell, and build artifacts into a project-local .nixy directory and update docs and executors accordingly.

New Features:
- Support per-architecture package URLs via a new sources map in nixy.yml.
- Persist generated workspace files such as flake.nix, shell-enter.sh, shell-env.sh, and build scripts in a .nixy directory under the project root.
- Expose a profile edit command and configurable profile-level nixy.yml loading via NIXY_USE_PROFILE.

Enhancements:
- Rename shell and build hook templates to shell-enter and build scripts and wire them through the template and execution pipeline.
- Simplify workspace flake directory handling by deriving it from the project directory instead of profile-specific workspace paths.
- Improve build script robustness by sanitizing target names, using explicit path-based nix invocations, and cleaning temporary directories after builds.

Documentation:
- Document the new sources-based package configuration format in README examples.
- Add documentation for inspectable generated files under the .nixy directory and recommend gitignoring them.
- Clarify profile isolation semantics, profile namespaces, and the use of NIXY_PROFILE and NIXY_USE_PROFILE.
- Update CLI command reference to include nixy profile edit and remove deprecated utility command listings.