### PR TITLE
ci: adds a github action for setting up nixy

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,26 +202,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v31
-
-      - name: Install nixy
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL -o "$HOME/.local/bin/nixy" \
-            https://github.com/nxtcoder17/nixy/releases/latest/download/nixy-linux-amd64
-          chmod +x "$HOME/.local/bin/nixy"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: nxtcoder17/nixy@v1
 
       - name: Build target
         working-directory: example/docker-build
-        run: nixy build runtime --dockerfile
+        run: nixy build runtime
 
       - name: Build Docker image from runtime bundle
+        working-directory: example/docker-build
         run: |
           docker build \
-            -f example/docker-build/Dockerfile \
+            -f Dockerfile \
             -t nixy-runtime:ci \
-            example/docker-build
+            .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,59 @@
+name: Setup Nixy
+description: Install Nix and nixy for CI workflows
+
+inputs:
+  version:
+    description: Nixy version to install, or latest
+    required: false
+    default: latest
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+
+    - name: Install nixy
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)
+            artifact="nixy-linux-amd64"
+            ;;
+          Linux-ARM64)
+            artifact="nixy-linux-arm64"
+            ;;
+          macOS-X64)
+            artifact="nixy-darwin-amd64"
+            ;;
+          macOS-ARM64)
+            artifact="nixy-darwin-arm64"
+            ;;
+          *)
+            echo "Unsupported runner: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        install_dir="${RUNNER_TEMP}/nixy/bin"
+        mkdir -p "$install_dir"
+
+        if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+          url="https://github.com/nxtcoder17/nixy/releases/latest/download/${artifact}"
+        else
+          url="https://github.com/nxtcoder17/nixy/releases/download/${VERSION}/${artifact}"
+        fi
+
+        curl --fail --silent --show-error --location --retry 3 "$url" --output "${install_dir}/nixy"
+        chmod +x "${install_dir}/nixy"
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+    - name: Verify nixy
+      shell: bash
+      run: nixy --help >/dev/null


### PR DESCRIPTION
## Summary by Sourcery

Add a reusable GitHub composite action to install Nix and nixy and update docs to use it in CI examples.

New Features:
- Introduce a composite GitHub Action for installing Nix and nixy with optional version selection.

Enhancements:
- Update README CI example to consume the new nixy setup action and simplify Docker build paths.